### PR TITLE
fix(update_engine): use coreos production certs/hosts

### DIFF
--- a/libcurl_http_fetcher.cc
+++ b/libcurl_http_fetcher.cc
@@ -28,7 +28,7 @@ namespace chromeos_update_engine {
 
 namespace {
 const int kNoNetworkRetrySeconds = 10;
-const char kCACertificatesPath[] = "/usr/share/chromeos-ca-certificates";
+const char kCACertificatesPath[] = "/usr/share/coreos-ca-certificates";
 }  // namespace {}
 
 const int LibcurlHttpFetcher::kMaxRedirects = 10;

--- a/omaha_request_params.cc
+++ b/omaha_request_params.cc
@@ -31,9 +31,8 @@ const char* const OmahaRequestParams::kAppId(
     "{e96281a6-d1af-4bde-9a0a-97b76e56dc57}");
 const char* const OmahaRequestParams::kOsPlatform("CoreOS");
 const char* const OmahaRequestParams::kOsVersion("Chateau");
-// TODOBP: Move to https://update.core-os.net/ once we have the SSL cert
 const char* const kProductionOmahaUrl(
-    "https://core-update.appspot.com/");
+    "https://api.core-os.net/update/");
 
 const char* const OmahaRequestParams::kUpdateChannelKey(
     "CHROMEOS_RELEASE_TRACK");


### PR DESCRIPTION
use the production certs and hosts for coreos
