### PR TITLE
feat(libcurl_http_fetcher): dump curl error

### DIFF
--- a/libcurl_http_fetcher.cc
+++ b/libcurl_http_fetcher.cc
@@ -69,6 +69,10 @@ void LibcurlHttpFetcher::ResumeTransfer(const std::string& url) {
   curl_handle_ = curl_easy_init();
   CHECK(curl_handle_);
 
+  CHECK_EQ(curl_easy_setopt(curl_handle_,
+                            CURLOPT_ERRORBUFFER,
+                            &curl_error_buffer_), CURLE_OK);
+
   CHECK(HasProxy());
   bool is_direct = (GetCurrentProxy() == kNoProxy);
   LOG(INFO) << "Using proxy: " << (is_direct ? "no" : "yes");
@@ -286,7 +290,7 @@ void LibcurlHttpFetcher::CurlPerformOnce() {
       LOG(INFO) << "HTTP response code: " << http_response_code_;
       no_network_retry_count_ = 0;
     } else {
-      LOG(ERROR) << "Unable to get http response code.";
+      LOG(ERROR) << "Unable to get http response code: " << curl_error_buffer_;
     }
 
     // we're done!

--- a/libcurl_http_fetcher.h
+++ b/libcurl_http_fetcher.h
@@ -261,6 +261,9 @@ class LibcurlHttpFetcher : public HttpFetcher {
   // if we get a terminate request, queue it until we can handle it.
   bool terminate_requested_;
 
+  // Buffer for curl to dump useful information into
+  char curl_error_buffer_[CURL_ERROR_SIZE] ;
+
   // Represents which server certificate to be checked against this
   // connection's certificate. If no certificate check needs to be performed,
   // this should be kNone.


### PR DESCRIPTION
On SSL errors, like CA certificate chain verification failure, no useful
log was being dumped. Fix this.
