### PR TITLE
feat(omaha_request): add the bootid

### DIFF
--- a/omaha_request_action.cc
+++ b/omaha_request_action.cc
@@ -208,6 +208,7 @@ string GetAppXml(const OmahaEvent* event,
       "    <app appid=\"" + XmlEncode(request_app_id) + "\" " +
                 app_versions +
                 app_channels +
+                "bootid=\"" + XmlEncode(params.bootid()) + "\" " +
                 "lang=\"" + XmlEncode(params.app_lang()) + "\" " +
                 "board=\"" + XmlEncode(params.os_board()) + "\" " +
                 "hardware_class=\"" + XmlEncode(params.hwid()) + "\" " +

--- a/omaha_request_action_unittest.cc
+++ b/omaha_request_action_unittest.cc
@@ -51,6 +51,7 @@ OmahaRequestParams kDefaultTestParams(
     "en-US",
     "unittest",
     "OEM MODEL 09235 7471",
+    "{8DA4B84F-2864-447D-84B7-C2D9B72924E7}",
     false,  // delta okay
     false,  // interactive
     "http://url",
@@ -827,6 +828,7 @@ TEST(OmahaRequestActionTest, XmlEncodeTest) {
                             "en-US",
                             "unittest_track&lt;",
                             "<OEM MODEL>",
+                            "{8DA4B84F-2864-447D-84B7-C2D9B72924E7}",
                             false,  // delta okay
                             false,  // interactive
                             "http://url",
@@ -852,6 +854,7 @@ TEST(OmahaRequestActionTest, XmlEncodeTest) {
   EXPECT_EQ(post_str.find("unittest_track&lt;"), string::npos);
   EXPECT_NE(post_str.find("&lt;OEM MODEL&gt;"), string::npos);
   EXPECT_EQ(post_str.find("<OEM MODEL>"), string::npos);
+  EXPECT_EQ(post_str.find("{8DA4B84F-2864-447D-84B7-C2D9B72924E7}"), string::npos);
 }
 
 TEST(OmahaRequestActionTest, XmlDecodeTest) {
@@ -927,6 +930,8 @@ TEST(OmahaRequestActionTest, FormatUpdateCheckOutputTest) {
       string::npos);
   EXPECT_NE(post_str.find("hardware_class=\"OEM MODEL 09235 7471\""),
             string::npos);
+  EXPECT_NE(post_str.find("bootid=\"{8DA4B84F-2864-447D-84B7-C2D9B72924E7}\""),
+            string::npos);
 }
 
 
@@ -953,6 +958,8 @@ TEST(OmahaRequestActionTest, FormatUpdateDisabledOutputTest) {
       "        <updatecheck targetversionprefix=\"\"></updatecheck>\n"),
       string::npos);
   EXPECT_NE(post_str.find("hardware_class=\"OEM MODEL 09235 7471\""),
+            string::npos);
+  EXPECT_NE(post_str.find("bootid=\"{8DA4B84F-2864-447D-84B7-C2D9B72924E7}\""),
             string::npos);
 }
 
@@ -1035,6 +1042,7 @@ TEST(OmahaRequestActionTest, FormatDeltaOkayOutputTest) {
                               "en-US",
                               "unittest_track",
                               "OEM MODEL REV 1234",
+                              "{88DC1453-ABB2-45F5-A622-1808F18E1B61}",
                               delta_okay,
                               false,  // interactive
                               "http://url",
@@ -1072,6 +1080,7 @@ TEST(OmahaRequestActionTest, FormatInteractiveOutputTest) {
                               "en-US",
                               "unittest_track",
                               "OEM MODEL REV 1234",
+                              "{88DC1453-ABB2-45F5-A622-1808F18E1B61}",
                               true,  // delta_okay
                               interactive,
                               "http://url",

--- a/omaha_request_params.cc
+++ b/omaha_request_params.cc
@@ -72,6 +72,7 @@ bool OmahaRequestParams::Init(const std::string& in_app_version,
                               stateful_override);
   app_lang_ = "en-US";
   hwid_ = utils::GetHardwareClass();
+  bootid_ = utils::GetBootId();
 
   if (current_channel_ == target_channel_) {
     // deltas are only okay if the /.nodelta file does not exist.  if we don't

--- a/omaha_request_params.h
+++ b/omaha_request_params.h
@@ -58,6 +58,7 @@ class OmahaRequestParams {
                      const std::string& in_app_lang,
                      const std::string& in_target_channel,
                      const std::string& in_hwid,
+                     const std::string& in_bootid,
                      bool in_delta_okay,
                      bool in_interactive,
                      const std::string& in_update_url,
@@ -75,6 +76,7 @@ class OmahaRequestParams {
         current_channel_(in_target_channel),
         target_channel_(in_target_channel),
         hwid_(in_hwid),
+        bootid_(in_bootid),
         delta_okay_(in_delta_okay),
         interactive_(in_interactive),
         update_url_(in_update_url),
@@ -97,6 +99,7 @@ class OmahaRequestParams {
   inline std::string board_app_id() const { return board_app_id_; }
   inline std::string app_lang() const { return app_lang_; }
   inline std::string hwid() const { return hwid_; }
+  inline std::string bootid() const { return bootid_; }
 
   inline void set_app_version(const std::string& version) {
     app_version_ = version;
@@ -271,6 +274,7 @@ class OmahaRequestParams {
   std::string current_channel_;
   std::string target_channel_;
   std::string hwid_;  // Hardware Qualification ID of the client
+  std::string bootid_;  // Kernel generated guid that identifies this boot
   bool delta_okay_;  // If this client can accept a delta
   bool interactive_;   // Whether this is a user-initiated update check
 

--- a/utils.cc
+++ b/utils.cc
@@ -57,6 +57,7 @@ const int kUnmountRetryIntervalInMicroseconds = 200 * 1000;  // 200 ms
 
 namespace utils {
 
+static const char kBootId[] = "/proc/sys/kernel/random/boot_id";
 static const char kDevImageMarker[] = "/root/.dev_mode";
 const char* const kStatefulPartition = "/mnt/stateful_partition";
 
@@ -98,6 +99,22 @@ string GetHardwareClass() {
   }
   LOG(ERROR) << "Unable to read HWID (" << exit_code << ") " << hwid;
   return "";
+}
+
+string GetBootId() {
+  string id;
+  string guid;
+  if (!file_util::ReadFileToString(FilePath(kBootId), &id)) {
+    LOG(ERROR) << "Unable to read boot_id";
+    return "";
+  }
+  TrimWhitespaceASCII(id, TRIM_ALL, &id);
+
+  // Make it look like the other UUIDs in the payload
+  guid.append(1, '{');
+  guid.append(id);
+  guid.append(1, '}');
+  return guid;
 }
 
 bool WriteFile(const char* path, const char* data, int data_len) {

--- a/utils.h
+++ b/utils.h
@@ -37,6 +37,9 @@ bool IsNormalBootMode();
 // Returns the HWID or an empty string on error.
 std::string GetHardwareClass();
 
+// Returns the boot_id or an empty string on error.
+std::string GetBootId();
+
 // Writes the data passed to path. The file at path will be overwritten if it
 // exists. Returns true on success, false otherwise.
 bool WriteFile(const char* path, const char* data, int data_len);


### PR DESCRIPTION
Add the UUID that the kernel generates into the update payload so we can
uniquely (and anonymously) identify a boot.

It comes from /proc/sys/kernel/random/boot_id
