### PR TITLE
feat(update_attempter): use coreos-setnext

### DIFF
--- a/update_attempter.cc
+++ b/update_attempter.cc
@@ -794,7 +794,7 @@ void UpdateAttempter::UpdateBootFlags() {
   // the script runtime.
   update_boot_flags_running_ = true;
   LOG(INFO) << "Updating boot flags...";
-  vector<string> cmd(1, "/usr/sbin/chromeos-setgoodkernel");
+  vector<string> cmd(1, "/usr/sbin/coreos-setgoodroot");
   if (!Subprocess::Get().Exec(cmd, StaticCompleteUpdateBootFlags, this)) {
     CompleteUpdateBootFlags(1);
   }

--- a/update_attempter.h
+++ b/update_attempter.h
@@ -106,7 +106,7 @@ class UpdateAttempter : public ActionProcessorDelegate,
                  std::string* new_version,
                  int64_t* new_size);
 
-  // Runs chromeos-setgoodkernel, whose responsibility it is to mark the
+  // Runs coreos-setgootroot, whose responsibility it is to mark the
   // currently booted partition has high priority/permanent/etc. The execution
   // is asynchronous. On completion, the action processor may be started
   // depending on the |start_action_processor_| field. Note that every update


### PR DESCRIPTION
call coreos-setgoodroot to make sure that our current root filesystem is
marked as successfully booted.
