### PR TITLE
fix(SConstruct): Preserve PATH

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -167,7 +167,7 @@ for key in Split('CFLAGS CCFLAGS CPPPATH LIBPATH'):
   if value != None:
     env[key] = Split(value)
 
-for key in Split('PKG_CONFIG_LIBDIR PKG_CONFIG_PATH SYSROOT'):
+for key in Split('PATH PKG_CONFIG_LIBDIR PKG_CONFIG_PATH SYSROOT'):
   if os.environ.has_key(key):
     env['ENV'][key] = os.environ[key]
 


### PR DESCRIPTION
The new sysroot wrappers must be found via PATH since they don't replace
the GCC binaries in-place like the old bundled ones did.
