### PR TITLE
fix(gpio_handler): add fcntl.h

### DIFF
--- a/gpio_handler.cc
+++ b/gpio_handler.cc
@@ -9,6 +9,7 @@
 #include <base/stringprintf.h>
 #include <base/time.h>
 #include <glib.h>
+#include <fcntl.h>
 
 #include "update_engine/file_descriptor.h"
 


### PR DESCRIPTION
O_WRONLY and O_RDONLY live in fcntl.h. Add it.
