### PR TITLE
fix(libcurl_http_fetcher): use a standard ssl certificate location

### DIFF
--- a/libcurl_http_fetcher.cc
+++ b/libcurl_http_fetcher.cc
@@ -28,7 +28,7 @@ namespace chromeos_update_engine {
 
 namespace {
 const int kNoNetworkRetrySeconds = 10;
-const char kCACertificatesPath[] = "/usr/share/coreos-ca-certificates";
+const char kCACertificatesPath[] = "/etc/ssl/certs";
 }  // namespace {}
 
 const int LibcurlHttpFetcher::kMaxRedirects = 10;


### PR DESCRIPTION
Before the update_engine only looked at our self-hosted copy of the update
service. But, other update service's can exist. Let them use a regular SSL
certificate and put it into /etc/certs/ssl.
