### PR TITLE
delta_performer: remove metadata size verification

### DIFF
--- a/download_action_unittest.cc
+++ b/download_action_unittest.cc
@@ -134,7 +134,6 @@ void TestWithData(const vector<char>& data,
                            "",
                            size,
                            hash,
-                           0,
                            output_temp_file.GetPath(),
                            "");
   ObjectFeederAction<InstallPlan> feeder_action;
@@ -251,7 +250,7 @@ void TestTerminateEarly(bool use_download_delegate) {
 
     // takes ownership of passed in HttpFetcher
     ObjectFeederAction<InstallPlan> feeder_action;
-    InstallPlan install_plan(false, "", 0, "", 0, temp_file.GetPath(), "");
+    InstallPlan install_plan(false, "", 0, "", temp_file.GetPath(), "");
     feeder_action.set_obj(install_plan);
     PrefsMock prefs;
     DownloadAction download_action(&prefs, NULL,
@@ -355,7 +354,6 @@ TEST(DownloadActionTest, PassObjectOutTest) {
                            "",
                            1,
                            OmahaHashCalculator::OmahaHashOfString("x"),
-                           0,
                            "/dev/null",
                            "/dev/null");
   ObjectFeederAction<InstallPlan> feeder_action;
@@ -392,7 +390,7 @@ TEST(DownloadActionTest, BadOutFileTest) {
   DirectFileWriter writer;
 
   // takes ownership of passed in HttpFetcher
-  InstallPlan install_plan(false, "", 0, "", 0, path, "");
+  InstallPlan install_plan(false, "", 0, "", path, "");
   ObjectFeederAction<InstallPlan> feeder_action;
   feeder_action.set_obj(install_plan);
   PrefsMock prefs;

--- a/filesystem_copier_action_unittest.cc
+++ b/filesystem_copier_action_unittest.cc
@@ -311,7 +311,7 @@ TEST_F(FilesystemCopierActionTest, ResumeTest) {
 
   ObjectFeederAction<InstallPlan> feeder_action;
   const char* kUrl = "http://some/url";
-  InstallPlan install_plan(true, kUrl, 0, "", 0, "", "");
+  InstallPlan install_plan(true, kUrl, 0, "", "", "");
   feeder_action.set_obj(install_plan);
   FilesystemCopierAction copier_action(false, false);
   ObjectCollectorAction<InstallPlan> collector_action;
@@ -340,7 +340,6 @@ TEST_F(FilesystemCopierActionTest, NonExistentDriveTest) {
                            "",
                            0,
                            "",
-                           0,
                            "/no/such/file",
                            "/no/such/file");
   feeder_action.set_obj(install_plan);

--- a/install_plan.cc
+++ b/install_plan.cc
@@ -16,14 +16,12 @@ InstallPlan::InstallPlan(bool is_resume,
                          const string& url,
                          uint64_t payload_size,
                          const string& payload_hash,
-                         uint64_t metadata_size,
                          const string& install_path,
                          const string& kernel_install_path)
     : is_resume(is_resume),
       download_url(url),
       payload_size(payload_size),
       payload_hash(payload_hash),
-      metadata_size(metadata_size),
       install_path(install_path),
       kernel_install_path(kernel_install_path),
       kernel_size(0),
@@ -33,7 +31,6 @@ InstallPlan::InstallPlan(bool is_resume,
 
 InstallPlan::InstallPlan() : is_resume(false),
                              payload_size(0),
-                             metadata_size(0),
                              kernel_size(0),
                              rootfs_size(0),
                              hash_checks_mandatory(false),
@@ -45,7 +42,6 @@ bool InstallPlan::operator==(const InstallPlan& that) const {
           (download_url == that.download_url) &&
           (payload_size == that.payload_size) &&
           (payload_hash == that.payload_hash) &&
-          (metadata_size == that.metadata_size) &&
           (install_path == that.install_path) &&
           (kernel_install_path == that.kernel_install_path));
 }
@@ -60,7 +56,6 @@ void InstallPlan::Dump() const {
             << ", url: " << download_url
             << ", payload size: " << payload_size
             << ", payload hash: " << payload_hash
-            << ", metadata size: " << metadata_size
             << ", install_path: " << install_path
             << ", kernel_install_path: " << kernel_install_path
             << ", hash_checks_mandatory: " << utils::ToString(

--- a/install_plan.h
+++ b/install_plan.h
@@ -19,7 +19,6 @@ struct InstallPlan {
               const std::string& url,
               uint64_t payload_size,
               const std::string& payload_hash,
-              uint64_t metadata_size,
               const std::string& install_path,
               const std::string& kernel_install_path);
 
@@ -37,7 +36,6 @@ struct InstallPlan {
 
   uint64_t payload_size;                 // size of the payload
   std::string payload_hash ;             // SHA256 hash of the payload
-  uint64_t metadata_size;                // size of the metadata
   std::string install_path;              // path to install device
   std::string kernel_install_path;       // path to kernel install device
 

--- a/omaha_request_action.cc
+++ b/omaha_request_action.cc
@@ -41,7 +41,7 @@ static const char* kTagMaxDaysToScatter = "MaxDaysToScatter";
 // Deprecated: "ManifestSignatureRsa"
 // Deprecated: "ManifestSize"
 // Deprecated: "MetadataSignatureRsa"
-static const char* kTagMetadataSize = "MetadataSize";
+// Deprecated: "MetadataSize"
 static const char* kTagMoreInfo = "MoreInfo";
 static const char* kTagNeedsAdmin = "needsadmin";
 static const char* kTagPrompt = "Prompt";
@@ -585,8 +585,6 @@ bool OmahaRequestAction::ParseParams(xmlDoc* doc,
   output_object->display_version =
       XmlGetProperty(pie_action_node, kTagDisplayVersion);
   output_object->more_info_url = XmlGetProperty(pie_action_node, kTagMoreInfo);
-  output_object->metadata_size =
-      ParseInt(XmlGetProperty(pie_action_node, kTagMetadataSize));
   output_object->needs_admin =
       XmlGetProperty(pie_action_node, kTagNeedsAdmin) == "true";
   output_object->prompt = XmlGetProperty(pie_action_node, kTagPrompt) == "true";

--- a/omaha_response.h
+++ b/omaha_response.h
@@ -21,7 +21,6 @@ struct OmahaResponse {
       : update_exists(false),
         poll_interval(0),
         size(0),
-        metadata_size(0),
         max_days_to_scatter(0),
         max_failure_count_per_url(0),
         needs_admin(false),
@@ -46,7 +45,6 @@ struct OmahaResponse {
   std::string hash;
   std::string deadline;
   off_t size;
-  off_t metadata_size;
   int max_days_to_scatter;
   // The number of URL-related failures to tolerate before moving on to the
   // next URL in the current pass. This is a configurable value from the

--- a/omaha_response_handler_action.cc
+++ b/omaha_response_handler_action.cc
@@ -47,7 +47,6 @@ void OmahaResponseHandlerAction::PerformAction() {
   // Fill up the other properties based on the response.
   install_plan_.payload_size = response.size;
   install_plan_.payload_hash = response.hash;
-  install_plan_.metadata_size = response.metadata_size;
   install_plan_.hash_checks_mandatory = AreHashChecksMandatory(response);
   install_plan_.is_resume =
       DeltaPerformer::CanResumeUpdate(system_state_->prefs(), response.hash);

--- a/payload_state.cc
+++ b/payload_state.cc
@@ -330,13 +330,11 @@ string PayloadState::CalculateResponseSignature() {
 
   response_sign += StringPrintf("Payload Size = %llu\n"
                                 "Payload Sha256 Hash = %s\n"
-                                "Metadata Size = %llu\n"
                                 "Is Delta Payload = %d\n"
                                 "Max Failure Count Per Url = %d\n"
                                 "Disable Payload Backoff = %d\n",
                                 response_.size,
                                 response_.hash.c_str(),
-                                response_.metadata_size,
                                 response_.is_delta_payload,
                                 response_.max_failure_count_per_url,
                                 response_.disable_payload_backoff);

--- a/payload_state_unittest.cc
+++ b/payload_state_unittest.cc
@@ -32,7 +32,6 @@ static void SetupPayloadStateWith2Urls(string hash,
   response->payload_urls.push_back("https://test");
   response->size = 523456789;
   response->hash = hash;
-  response->metadata_size = 558123;
   response->max_failure_count_per_url = 3;
   payload_state->SetResponse(*response);
   string stored_response_sign = payload_state->GetResponseSignature();
@@ -42,7 +41,6 @@ static void SetupPayloadStateWith2Urls(string hash,
       "Url1 = https://test\n"
       "Payload Size = 523456789\n"
       "Payload Sha256 Hash = %s\n"
-      "Metadata Size = 558123\n"
       "Is Delta Payload = %d\n"
       "Max Failure Count Per Url = %d\n"
       "Disable Payload Backoff = %d\n",
@@ -69,7 +67,6 @@ TEST(PayloadStateTest, SetResponseWorksWithEmptyResponse) {
   string expected_response_sign = "NumURLs = 0\n"
                                   "Payload Size = 0\n"
                                   "Payload Sha256 Hash = \n"
-                                  "Metadata Size = 0\n"
                                   "Is Delta Payload = 0\n"
                                   "Max Failure Count Per Url = 0\n"
                                   "Disable Payload Backoff = 0\n";
@@ -83,7 +80,6 @@ TEST(PayloadStateTest, SetResponseWorksWithSingleUrl) {
   response.payload_urls.push_back("http://single.url.test");
   response.size = 123456789;
   response.hash = "hash";
-  response.metadata_size = 58123;
   NiceMock<PrefsMock> prefs;
   EXPECT_CALL(prefs, SetInt64(kPrefsPayloadAttemptNumber, 0));
   EXPECT_CALL(prefs, SetInt64(kPrefsBackoffExpiryTime, 0));
@@ -97,7 +93,6 @@ TEST(PayloadStateTest, SetResponseWorksWithSingleUrl) {
                                   "Url0 = http://single.url.test\n"
                                   "Payload Size = 123456789\n"
                                   "Payload Sha256 Hash = hash\n"
-                                  "Metadata Size = 58123\n"
                                   "Is Delta Payload = 0\n"
                                   "Max Failure Count Per Url = 0\n"
                                   "Disable Payload Backoff = 0\n";
@@ -112,7 +107,6 @@ TEST(PayloadStateTest, SetResponseWorksWithMultipleUrls) {
   response.payload_urls.push_back("https://multiple.url.test");
   response.size = 523456789;
   response.hash = "rhash";
-  response.metadata_size = 558123;
   NiceMock<PrefsMock> prefs;
   EXPECT_CALL(prefs, SetInt64(kPrefsPayloadAttemptNumber, 0));
   EXPECT_CALL(prefs, SetInt64(kPrefsBackoffExpiryTime, 0));
@@ -127,7 +121,6 @@ TEST(PayloadStateTest, SetResponseWorksWithMultipleUrls) {
                                   "Url1 = https://multiple.url.test\n"
                                   "Payload Size = 523456789\n"
                                   "Payload Sha256 Hash = rhash\n"
-                                  "Metadata Size = 558123\n"
                                   "Is Delta Payload = 0\n"
                                   "Max Failure Count Per Url = 0\n"
                                   "Disable Payload Backoff = 0\n";


### PR DESCRIPTION
Follow up to de796c7b which removed signature verification. Now the
omaha server doesn't need to provide any update_engine specific data.
