### PR TITLE
Add a hook for OEMs in coreos-postinst

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -5,6 +5,8 @@
 
 set -e
 
+OEM_MNT="/usr/share/oem"
+
 INSTALL_MNT=$(dirname "$0")
 INSTALL_DEV="$1"
 
@@ -70,6 +72,11 @@ cp -v "${INSTALL_MNT}/boot/grub/menu.lst.${SLOT}" \
 if [[ $(systemd-detect-virt) == xen ]]; then
     cp -v "${INSTALL_MNT}/boot/syslinux/default.cfg.${SLOT}" \
         "${ESP_MNT}/syslinux/default.cfg"
+fi
+
+# If the OEM provides a hook, call it
+if [[ -x "${OEM_MNT}/bin/oem-postinst" ]]; then
+    "${OEM_MNT}/bin/oem-postinst" "${SLOT}" "${INSTALL_MNT}"
 fi
 
 # use the cgpt binary from the image to ensure compatibility


### PR DESCRIPTION
This will give me the ability to work around Linode's funky pv-grub environment. All I'd have to do is make a simple script `/usr/share/oem/oem-postinst`:

``` sh
#!/bin/bash

set -e

SLOT="$1"
INSTALL_MNT="$2"

LINODE_DEV="/dev/xvda"
LINODE_MNT="/linode"

mkdir -p "${LINODE_MNT}"
mount "${LINODE_DEV}" "${LINODE_MNT}"
trap "umount '${LINODE_MNT}' && rmdir '${LINODE_MNT}'" EXIT

cp -v "${INSTALL_MNT}/boot/grub/menu.lst.${SLOT}" \
    "${LINODE_MNT}/boot/grub/menu.lst"

sed -i 's/(hd0,0)/(hd1,0)/' "${LINODE_MNT}/boot/grub/menu.lst"
```

Don't judge me too harshly, I'm a bit of a novice with shell scripts.
