### PR TITLE
postinst: work around broken locksmith version

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 
 set -e
+umask 0022
 
 OEM_MNT="/usr/share/oem"
 
@@ -77,6 +78,25 @@ fi
 # If the OEM provides a hook, call it
 if [[ -x "${OEM_MNT}/bin/oem-postinst" ]]; then
     "${OEM_MNT}/bin/oem-postinst" "${SLOT}" "${INSTALL_MNT}"
+fi
+
+# locksmith 0.1.5 is broken, restart it lots to work around the issue
+if systemctl is-active --quiet locksmithd.service && \
+    locksmithctl help | grep -A1 '^VERSION:' | grep -q '0.1.5$';
+then
+    echo "Broken locksmith 0.1.5 detected, installing workaround timer."
+    # In one minute start restarting locksmithd every 5 minutes.
+    cat >/run/systemd/system/locksmithd-kicker.timer <<EOF
+[Timer]
+OnActiveSec=1min
+OnUnitActiveSec=5min
+EOF
+    cat >/run/systemd/system/locksmithd-kicker.service <<EOF
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl try-restart --no-block locksmithd.service
+EOF
+    systemctl start --no-block locksmithd-kicker.timer
 fi
 
 # use the cgpt binary from the image to ensure compatibility


### PR DESCRIPTION
locksmithd 0.1.5 only handles a single event from update_engine. To work
around the issue install a timer and service to start periodically
restarting locksmithd so it will check the current update_engine state.
