### PR TITLE
omaha_request_action: do not generate useless core dumps

### DIFF
--- a/omaha_request_action.cc
+++ b/omaha_request_action.cc
@@ -619,8 +619,7 @@ void OmahaRequestAction::TransferComplete(HttpFetcher *fetcher,
     CHECK(!HasOutputPipe()) << "No output pipe allowed for event requests.";
     if (event_->result == OmahaEvent::kResultError && successful &&
         utils::IsOfficialBuild()) {
-      LOG(INFO) << "Signalling Crash Reporter.";
-      utils::ScheduleCrashReporterUpload();
+      LOG(ERROR) << "HTTP reported success but Omaha reports an error.";
     }
     completer.set_code(kActionCodeSuccess);
     return;

--- a/utils.cc
+++ b/utils.cc
@@ -627,27 +627,6 @@ bool Reboot() {
   return true;
 }
 
-namespace {
-// Do the actual trigger. We do it as a main-loop callback to (try to) get a
-// consistent stack trace.
-gboolean TriggerCrashReporterUpload(void* unused) {
-  pid_t pid = fork();
-  CHECK(pid >= 0) << "fork failed";  // fork() failed. Something is very wrong.
-  if (pid == 0) {
-    // We are the child. Crash.
-    abort();  // never returns
-  }
-  // We are the parent. Wait for child to terminate.
-  pid_t result = waitpid(pid, NULL, 0);
-  LOG_IF(ERROR, result < 0) << "waitpid() failed";
-  return FALSE;  // Don't call this callback again
-}
-}  // namespace {}
-
-void ScheduleCrashReporterUpload() {
-  g_idle_add(&TriggerCrashReporterUpload, NULL);
-}
-
 bool SetCpuShares(CpuShares shares) {
   string string_shares = base::IntToString(static_cast<int>(shares));
   string cpu_shares_file = string(utils::kCGroupDir) + "/cpu.shares";

--- a/utils_unittest.cc
+++ b/utils_unittest.cc
@@ -231,22 +231,4 @@ TEST(UtilsTest, RunAsRootGetFilesystemSizeTest) {
   EXPECT_EQ(10 * 1024 * 1024 / 4096, block_count);
 }
 
-namespace {
-gboolean  TerminateScheduleCrashReporterUploadTest(void* arg) {
-  GMainLoop* loop = reinterpret_cast<GMainLoop*>(arg);
-  g_main_loop_quit(loop);
-  return FALSE;  // Don't call this callback again
-}
-}  // namespace {}
-
-TEST(UtilsTest, DISABLED_ScheduleCrashReporterUploadTest) {
-  // Not much to test. At least this tests for memory leaks, crashes,
-  // log errors.
-  GMainLoop* loop = g_main_loop_new(g_main_context_default(), FALSE);
-  utils::ScheduleCrashReporterUpload();
-  g_timeout_add_seconds(1, &TerminateScheduleCrashReporterUploadTest, loop);
-  g_main_loop_run(loop);
-  g_main_loop_unref(loop);
-}
-
 }  // namespace chromeos_update_engine


### PR DESCRIPTION
When HTTP reports success but the Omaha response includes an error just
log an error and move on instead of triggering a pointless core dump.

The weirdest thing is the core dump is made via a call back from the
main event loop so the dump doesn't actually include any context for
what triggered the dump. Gone now. :)
