### PR TITLE
omaha_request_params: fix reading OEM attributes

### DIFF
--- a/omaha_request_params.cc
+++ b/omaha_request_params.cc
@@ -89,7 +89,7 @@ string OmahaRequestParams::GetConfValue(const string& key,
 string OmahaRequestParams::GetOemValue(const string& key,
                                        const string& default_value) const {
   vector<string> files;
-  files.push_back("/etc/coreos/update.conf");
+  files.push_back("/etc/oem-release");
   return SearchConfValue(files, key, default_value);
 }
 


### PR DESCRIPTION
This was broken 92dae274 during some refactoring.
