### PR TITLE
Persist the first version in a pref and include it in omaha req attrs

### DIFF
--- a/omaha_request_action.cc
+++ b/omaha_request_action.cc
@@ -165,6 +165,7 @@ string GetAppXml(const OmahaEvent* event,
                 "bootid=\"" + XmlEncode(params.bootid()) + "\" " +
                 "oem=\"" + XmlEncode(params.oemid()) + "\" " +
                 "oemversion=\"" + XmlEncode(params.oemversion()) + "\" " +
+                "alephversion=\"" + XmlEncode(params.alephversion()) + "\" " +
                 "machineid=\"" + XmlEncode(params.machineid()) + "\" " +
                 "lang=\"" + XmlEncode(params.app_lang()) + "\" " +
                 "board=\"" + XmlEncode(params.os_board()) + "\" " +

--- a/omaha_request_params.cc
+++ b/omaha_request_params.cc
@@ -17,6 +17,7 @@
 
 #include "update_engine/simple_key_value_store.h"
 #include "update_engine/system_state.h"
+#include "update_engine/prefs_interface.h"
 #include "update_engine/utils.h"
 
 #define CALL_MEMBER_FN(object, member) ((object).*(member))
@@ -41,6 +42,12 @@ bool OmahaRequestParams::Init(bool interactive) {
   oemid_ = GetOemValue("ID", "");
   oemversion_ = GetOemValue("VERSION_ID", "");
   app_version_ = GetConfValue("COREOS_RELEASE_VERSION", "");
+
+  if (!system_state_->prefs()->GetString(kPrefsAlephVersion, &alephversion_)) {
+    alephversion_ = app_version_;
+    system_state_->prefs()->SetString(kPrefsAlephVersion, alephversion_);
+  }
+
   os_sp_ = app_version_ + "_" + GetMachineType();
   os_board_ = GetConfValue("COREOS_RELEASE_BOARD", "");
   app_id_ = GetConfValue("COREOS_RELEASE_APPID", OmahaRequestParams::kAppId);

--- a/omaha_request_params.h
+++ b/omaha_request_params.h
@@ -93,6 +93,7 @@ class OmahaRequestParams {
   inline std::string machineid() const { return machineid_; }
   inline std::string oemid() const { return oemid_; }
   inline std::string oemversion() const { return oemversion_; }
+  inline std::string alephversion() const { return alephversion_; }
 
   inline void set_app_version(const std::string& version) {
     app_version_ = version;
@@ -209,6 +210,7 @@ class OmahaRequestParams {
   std::string machineid_; // Unique machine ID that is set during installation 
   std::string oemid_; // Unique machine ID that is set during installation 
   std::string oemversion_; // CoreOS version set during installation
+  std::string alephversion_; // first CoreOS version cached by update_engine
   bool delta_okay_;  // If this client can accept a delta
   bool interactive_;   // Whether this is a user-initiated update check
 

--- a/prefs.cc
+++ b/prefs.cc
@@ -40,6 +40,7 @@ const char kPrefsCurrentResponseSignature[] = "current-response-signature";
 const char kPrefsCurrentUrlIndex[] = "current-url-index";
 const char kPrefsCurrentUrlFailureCount[] = "current-url-failure-count";
 const char kPrefsBackoffExpiryTime[] = "backoff-expiry-time";
+const char kPrefsAlephVersion[] = "aleph-version";
 
 bool Prefs::Init(const FilePath& prefs_dir) {
   prefs_dir_ = prefs_dir;

--- a/prefs_interface.h
+++ b/prefs_interface.h
@@ -30,6 +30,7 @@ extern const char kPrefsCurrentResponseSignature[];
 extern const char kPrefsCurrentUrlIndex[];
 extern const char kPrefsCurrentUrlFailureCount[];
 extern const char kPrefsBackoffExpiryTime[];
+extern const char kPrefsAlephVersion[];
 
 // The prefs interface allows access to a persistent preferences
 // store. The two reasons for providing this as an interface are


### PR DESCRIPTION
The pref is named "aleph-version", and the omaha req app attr
"alephversion":
$ cat /var/lib/update_engine/prefs/aleph-version
444.0.0+2014-09-22-1720

$ journalctl -u update-engine | grep aleph
Sep 25 00:08:20 coreos_developer_qemu-444-0-0-20 update_engine[1791]:
<app appid="{e96281a6-d1af-4bde-9a0a-97b76e56dc57}"
version="444.0.0+2014-09-22-1720" track="developer"
bootid="{60f9cf6a-361a-45f1-bb86-22380189907a}" oem="" oemversion=""
alephversion="444.0.0+2014-09-22-1720"
machineid="83ab5976451549a1afede31db82fd215" lang="en-US"
board="amd64-usr" hardware_class="" delta_okay="false" >
