### PR TITLE
postinst: allow any system to skip kexec, not just Xen

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -69,8 +69,8 @@ cp -v "${INSTALL_MNT}/boot/syslinux/root.${SLOT}.cfg" \
 cp -v "${INSTALL_MNT}/boot/grub/menu.lst.${SLOT}" \
     "${ESP_MNT}/boot/grub/menu.lst"
 
-# For Xen HVM, the default boot_kernel w/ kexec doesn't work
-if [[ $(systemd-detect-virt) == xen ]]; then
+# For systems that have disabled boot_kernel and kexec
+if ! grep -q boot_kernel "${ESP_MNT}/syslinux/default.cfg"; then
     cp -v "${INSTALL_MNT}/boot/syslinux/default.cfg.${SLOT}" \
         "${ESP_MNT}/syslinux/default.cfg"
 fi


### PR DESCRIPTION
The number of platforms that have to disable kexec has grown. Instead of
explicitly detecting one, Xen, test directly for whether the system is
configured to use boot_kernel or boot directly into the latest version.

Required for https://github.com/coreos/bugs/issues/75 and https://github.com/coreos/bugs/issues/68
