### PR TITLE
string::assign appversion to alephversion and enhance prefs unit tests

### DIFF
--- a/omaha_request_params.cc
+++ b/omaha_request_params.cc
@@ -44,7 +44,7 @@ bool OmahaRequestParams::Init(bool interactive) {
   app_version_ = GetConfValue("COREOS_RELEASE_VERSION", "");
 
   if (!system_state_->prefs()->GetString(kPrefsAlephVersion, &alephversion_)) {
-    alephversion_ = app_version_;
+    alephversion_.assign(app_version_);
     system_state_->prefs()->SetString(kPrefsAlephVersion, alephversion_);
   }
 

--- a/prefs_unittest.cc
+++ b/prefs_unittest.cc
@@ -43,6 +43,8 @@ TEST_F(PrefsTest, GetFileNameForKey) {
   FilePath path;
   EXPECT_TRUE(prefs_.GetFileNameForKey(kKey, &path));
   EXPECT_EQ(prefs_dir_.Append(kKey).value(), path.value());
+  EXPECT_TRUE(prefs_.GetFileNameForKey(kKey, &path));
+  EXPECT_EQ(prefs_dir_.Append(kKey).value(), path.value());
 }
 
 TEST_F(PrefsTest, GetFileNameForKeyBadCharacter) {
@@ -62,6 +64,8 @@ TEST_F(PrefsTest, GetString) {
   string value;
   EXPECT_TRUE(prefs_.GetString(kKey, &value));
   EXPECT_EQ(test_data, value);
+  EXPECT_TRUE(prefs_.GetString(kKey, &value));
+  EXPECT_EQ(test_data, value);
 }
 
 TEST_F(PrefsTest, GetStringBadKey) {
@@ -79,6 +83,9 @@ TEST_F(PrefsTest, SetString) {
   const char kValue[] = "some test value\non 2 lines";
   EXPECT_TRUE(prefs_.SetString(kKey, kValue));
   string value;
+  EXPECT_TRUE(file_util::ReadFileToString(prefs_dir_.Append(kKey), &value));
+  EXPECT_EQ(kValue, value);
+  EXPECT_TRUE(prefs_.SetString(kKey, kValue));
   EXPECT_TRUE(file_util::ReadFileToString(prefs_dir_.Append(kKey), &value));
   EXPECT_EQ(kValue, value);
 }


### PR DESCRIPTION
Existing Prefs unit tests didn't catch an append bug in libchrome's
file_util::ReadFileToString().  Change the get/set tests to verify idempotence,
the Prefs tests now fail without a fixed libchrome.
