### PR TITLE
postinst: skip updating bootloader configuration on new GRUB systems

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -23,56 +23,59 @@ case "${INSTALL_LABEL}" in
         exit 1
 esac
 
-# Find the ESP partition and mount it if needed
-ESP_PARTTYPE="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
-ESP_MNT=
+# Update bootloaders from CoreOS <= 522.x.x
+if grep -q cros_legacy /proc/cmdline; then
+    # Find the ESP partition and mount it if needed
+    ESP_PARTTYPE="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+    ESP_MNT=
 
-declare -a DEV_LIST
-mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,MOUNTPOINT)
+    declare -a DEV_LIST
+    mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,MOUNTPOINT)
 
-for dev_info in "${DEV_LIST[@]}"; do
-    eval "$dev_info"
+    for dev_info in "${DEV_LIST[@]}"; do
+        eval "$dev_info"
 
-    if [[ "${PARTTYPE}" != "${ESP_PARTTYPE}" ]]; then
-        continue
+        if [[ "${PARTTYPE}" != "${ESP_PARTTYPE}" ]]; then
+            continue
+        fi
+
+        if [[ -n "${MOUNTPOINT}" ]]; then
+            ESP_MNT="${MOUNTPOINT}"
+        else
+            ESP_MNT="$(mktemp -d /tmp/postinst_esp.XXXXXXXXXX)"
+            mount "/dev/${NAME}" "${ESP_MNT}"
+            trap "umount '${ESP_MNT}' && rmdir '${ESP_MNT}'" EXIT
+        fi
+
+        break
+    done
+
+    if [[ -z "${ESP_MNT}" ]]; then
+        echo "Failed to find ESP partition!" >&2
+        exit 1
     fi
 
-    if [[ -n "${MOUNTPOINT}" ]]; then
-        ESP_MNT="${MOUNTPOINT}"
-    else
-        ESP_MNT="$(mktemp -d /tmp/postinst_esp.XXXXXXXXXX)"
-        mount "/dev/${NAME}" "${ESP_MNT}"
-        trap "umount '${ESP_MNT}' && rmdir '${ESP_MNT}'" EXIT
+    if [[ ! -d "${ESP_MNT}" ]]; then
+        echo "ESP partition mount point (${ESP_MNT}) is not a directory!" >&2
+        exit 1
     fi
 
-    break
-done
+    # Update kernel and bootloader configs
+    mkdir -p "${ESP_MNT}"{/syslinux,/boot/grub}
+    cp -v "${INSTALL_MNT}/boot/vmlinuz" \
+        "${ESP_MNT}/syslinux/vmlinuz.${SLOT}"
+    cp -v "${INSTALL_MNT}/boot/syslinux/root.${SLOT}.cfg" \
+        "${ESP_MNT}/syslinux/root.${SLOT}.cfg"
 
-if [[ -z "${ESP_MNT}" ]]; then
-    echo "Failed to find ESP partition!" >&2
-    exit 1
-fi
+    # For Xen's pvgrub
+    cp -v "${INSTALL_MNT}/boot/grub/menu.lst.${SLOT}" \
+        "${ESP_MNT}/boot/grub/menu.lst"
 
-if [[ ! -d "${ESP_MNT}" ]]; then
-    echo "ESP partition mount point (${ESP_MNT}) is not a directory!" >&2
-    exit 1
-fi
-
-# Update kernel and bootloader configs
-mkdir -p "${ESP_MNT}"{/syslinux,/boot/grub}
-cp -v "${INSTALL_MNT}/boot/vmlinuz" \
-    "${ESP_MNT}/syslinux/vmlinuz.${SLOT}"
-cp -v "${INSTALL_MNT}/boot/syslinux/root.${SLOT}.cfg" \
-    "${ESP_MNT}/syslinux/root.${SLOT}.cfg"
-
-# For Xen's pvgrub
-cp -v "${INSTALL_MNT}/boot/grub/menu.lst.${SLOT}" \
-    "${ESP_MNT}/boot/grub/menu.lst"
-
-# For systems that have disabled boot_kernel and kexec
-if ! grep -q boot_kernel "${ESP_MNT}/syslinux/default.cfg"; then
-    cp -v "${INSTALL_MNT}/boot/syslinux/default.cfg.${SLOT}" \
-        "${ESP_MNT}/syslinux/default.cfg"
+    # For systems that have disabled boot_kernel and kexec
+    if ! grep -q boot_kernel "${ESP_MNT}/syslinux/default.cfg"; then
+        cp -v "${INSTALL_MNT}/boot/syslinux/default.cfg.${SLOT}" \
+            "${ESP_MNT}/syslinux/default.cfg"
+    fi
 fi
 
 # If the OEM provides a hook, call it


### PR DESCRIPTION
Here is the diff ignoring the indentation change:

``` patch
diff --git a/coreos-postinst b/coreos-postinst
index 2161aad..33ab39b 100644
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -23,6 +23,8 @@ case "${INSTALL_LABEL}" in
         exit 1
 esac

+# Update bootloaders from CoreOS <= 522.x.x
+if grep -q cros_legacy /proc/cmdline; then
     # Find the ESP partition and mount it if needed
     ESP_PARTTYPE="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
     ESP_MNT=
@@ -74,6 +76,7 @@ if ! grep -q boot_kernel "${ESP_MNT}/syslinux/default.cfg"; then
         cp -v "${INSTALL_MNT}/boot/syslinux/default.cfg.${SLOT}" \
             "${ESP_MNT}/syslinux/default.cfg"
     fi
+fi

 # If the OEM provides a hook, call it
 if [[ -x "${OEM_MNT}/bin/oem-postinst" ]]; then
```
