### PR TITLE
Fix update-engine failed to write cpu.shares

### DIFF
--- a/systemd/update-engine.service
+++ b/systemd/update-engine.service
@@ -6,6 +6,7 @@ ConditionPathExists=!/usr/.noupdate
 [Service]
 Type=dbus
 BusName=com.coreos.update1
+ExecStartPre=-/usr/bin/mkdir /sys/fs/cgroup/cpu/update-engine
 ExecStart=/usr/sbin/update_engine -foreground -logtostderr -no_connection_manager
 BlockIOWeight=100
 Restart=always

--- a/utils.cc
+++ b/utils.cc
@@ -61,8 +61,8 @@ static const char kMachineId[] = "/etc/machine-id";
 static const char kDevImageMarker[] = "/root/.dev_mode";
 const char* const kStatefulPartition = "/media/state";
 
-// Cgroup container is created in update-engine's upstart script located at
-// /etc/init/update-engine.conf.
+// Cgroup container is created in update-engine.service prior to start
+// update-engine.
 static const char kCGroupDir[] = "/sys/fs/cgroup/cpu/update-engine";
 
 bool IsOfficialBuild() {


### PR DESCRIPTION
We now using systemd and will create cgroup controller for update-engine in
systemd way to prevent below error.

[1208/053539:INFO:utils.cc(633)] Setting cgroup cpu shares to  2
[1208/053539:ERROR:utils.cc(118)] 0 == writer.Open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600) failed: No such file or directory
[1208/053539:ERROR:utils.cc(638)] Failed to change cgroup cpu shares to 2 using /sys/fs/cgroup/cpu/update-engine/cpu.shares

Signed-off-by: Chengwei Yang <yangchengwei@qiyi.com>