### PR TITLE
Fix a warning, make noise about two others.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -186,7 +186,6 @@ env['CCFLAGS'] = ' '.join("""-g
                              -Wsign-compare
                              -Wtype-limits
                              -Wuninitialized
-                             -Wno-error=deprecated-declarations
                              -D__STDC_FORMAT_MACROS=1
                              -D_FILE_OFFSET_BITS=64""".split());
 env['CCFLAGS'] += (' ' + ' '.join(env['CFLAGS']))

--- a/SConstruct
+++ b/SConstruct
@@ -182,10 +182,10 @@ env['CCFLAGS'] = ' '.join("""-g
                              -Werror
                              -Wignored-qualifiers
                              -Wmissing-field-initializers
-                             -Wno-format
                              -Wsign-compare
                              -Wtype-limits
                              -Wuninitialized
+                             -Wno-error=format
                              -Wno-error=unused-local-typedefs
                              -D__STDC_FORMAT_MACROS=1
                              -D_FILE_OFFSET_BITS=64""".split());

--- a/SConstruct
+++ b/SConstruct
@@ -186,6 +186,7 @@ env['CCFLAGS'] = ' '.join("""-g
                              -Wsign-compare
                              -Wtype-limits
                              -Wuninitialized
+                             -Wno-error=unused-local-typedefs
                              -D__STDC_FORMAT_MACROS=1
                              -D_FILE_OFFSET_BITS=64""".split());
 env['CCFLAGS'] += (' ' + ' '.join(env['CFLAGS']))

--- a/main.cc
+++ b/main.cc
@@ -142,8 +142,6 @@ void SetupLogging() {
 }  // namespace chromeos_update_engine
 
 int main(int argc, char** argv) {
-  // FIXME: g_type_init is deprecated, remove once updated to glib >= 3.36
-  ::g_type_init();
   dbus_threads_init_default();
   base::AtExitManager exit_manager;  // Required for base/rand_util.h.
   chromeos_update_engine::Terminator::Init();

--- a/testrunner.cc
+++ b/testrunner.cc
@@ -18,8 +18,6 @@
 
 int main(int argc, char **argv) {
   LOG(INFO) << "started";
-  // FIXME: g_type_init is deprecated, remove once updated to glib >= 3.36
-  ::g_type_init();
   dbus_threads_init_default();
   base::AtExitManager exit_manager;
   // TODO(garnold) temporarily cause the unittest binary to exit with status

--- a/update_engine_client.cc
+++ b/update_engine_client.cc
@@ -210,8 +210,6 @@ void CompleteUpdate() {
 
 int main(int argc, char** argv) {
   // Boilerplate init commands.
-  // FIXME: g_type_init is deprecated, remove once updated to glib >= 3.36
-  g_type_init();
   dbus_threads_init_default();
   chromeos_update_engine::Subprocess::Init();
   google::ParseCommandLineFlags(&argc, &argv, true);


### PR DESCRIPTION
Note: glib >= 2.36 is now required. CoreOS currently ships 2.40.0