### PR TITLE
build: fix format string warnings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -185,7 +185,6 @@ env['CCFLAGS'] = ' '.join("""-g
                              -Wsign-compare
                              -Wtype-limits
                              -Wuninitialized
-                             -Wno-error=format
                              -Wno-error=unused-local-typedefs
                              -D__STDC_FORMAT_MACROS=1
                              -D_FILE_OFFSET_BITS=64""".split());

--- a/delta_diff_generator.cc
+++ b/delta_diff_generator.cc
@@ -477,17 +477,18 @@ void ReportPayloadUsage(const DeltaArchiveManifest& manifest,
 
   std::sort(objects.begin(), objects.end());
 
-  static const char kFormatString[] = "%6.2f%% %10llu %-10s %s\n";
+  static const char kFormatString[] = "%6.2f%% %10jd %-10s %s\n";
   for (vector<DeltaObject>::const_iterator it = objects.begin();
        it != objects.end(); ++it) {
     const DeltaObject& object = *it;
     fprintf(stderr, kFormatString,
             object.size * 100.0 / total_size,
-            object.size,
+            static_cast<intmax_t>(object.size),
             object.type >= 0 ? kInstallOperationTypes[object.type] : "-",
             object.name.c_str());
   }
-  fprintf(stderr, kFormatString, 100.0, total_size, "", "<total>");
+  fprintf(stderr, kFormatString,
+          100.0, static_cast<intmax_t>(total_size), "", "<total>");
 }
 
 }  // namespace {}

--- a/delta_performer.cc
+++ b/delta_performer.cc
@@ -133,7 +133,7 @@ void DeltaPerformer::LogProgress(const char* message_prefix) {
     total_operations_str = StringPrintf("%zu", num_total_operations_);
     // Upcasting to 64-bit to avoid overflow, back to size_t for formatting.
     completed_percentage_str =
-        StringPrintf(" (%llu%%)",
+        StringPrintf(" (%" PRIu64 "%%)",
                      IntRatio(next_operation_num_, num_total_operations_,
                               100));
   }
@@ -146,7 +146,7 @@ void DeltaPerformer::LogProgress(const char* message_prefix) {
     payload_size_str = StringPrintf("%zu", payload_size);
     // Upcasting to 64-bit to avoid overflow, back to size_t for formatting.
     downloaded_percentage_str =
-        StringPrintf(" (%llu%%)",
+        StringPrintf(" (%" PRIu64 "%%)",
                      IntRatio(total_bytes_received_, payload_size, 100));
   }
 

--- a/payload_state.cc
+++ b/payload_state.cc
@@ -321,19 +321,19 @@ void PayloadState::ResetPersistedState() {
 }
 
 string PayloadState::CalculateResponseSignature() {
-  string response_sign = StringPrintf("NumURLs = %d\n",
+  string response_sign = StringPrintf("NumURLs = %zu\n",
                                       response_.payload_urls.size());
 
   for (size_t i = 0; i < response_.payload_urls.size(); i++)
-    response_sign += StringPrintf("Url%d = %s\n",
+    response_sign += StringPrintf("Url%zu = %s\n",
                                   i, response_.payload_urls[i].c_str());
 
-  response_sign += StringPrintf("Payload Size = %llu\n"
+  response_sign += StringPrintf("Payload Size = %jd\n"
                                 "Payload Sha256 Hash = %s\n"
                                 "Is Delta Payload = %d\n"
                                 "Max Failure Count Per Url = %d\n"
                                 "Disable Payload Backoff = %d\n",
-                                response_.size,
+                                static_cast<intmax_t>(response_.size),
                                 response_.hash.c_str(),
                                 response_.is_delta_payload,
                                 response_.max_failure_count_per_url,


### PR DESCRIPTION
Related ChromiumOS commit that also fixed these errors:
https://chromium.googlesource.com/chromiumos/platform/update_engine/+/75039d7397f03dff77bdf4e26398049ff88edc4c

Differences from that commit:
 - off_t is signed, so don't cast to unsigned
 - size_t can use %zu, no casting required