### PR TITLE
build: fix delta_generator and enable by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,7 @@ update_engine_SOURCES = src/update_engine/main.cc \
 			src/update_engine/update_engine.dbusserver.h
 
 delta_generator_LDADD = libupdate_engine.a $(LDADD)
-delta_generator_SOURCES = generate_delta_main.cc
+delta_generator_SOURCES = src/update_engine/generate_delta_main.cc
 
 update_engine_client_LDADD = libupdate_engine.a $(LDADD)
 update_engine_client_SOURCES = src/update_engine/update_engine_client.cc \

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,8 @@ PKG_CHECK_MODULES([DEPS],
 
 AC_ARG_ENABLE([delta_generator],
               [AS_HELP_STRING([--enable-delta_generator],
-                              [build delta_generator])])
+                              [build delta_generator])],
+              [], [enable_delta_generator=yes])
 AM_CONDITIONAL([ENABLE_DELTA_GENERATOR],
                [test "x$enable_delta_generator" = "xyes"])
 


### PR DESCRIPTION
Missed this in 918a9d80, I thought I was building everything but
overlooked that configure wasn't enabling this option.