### PR TITLE
Support kernel payloads in Update Engine

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -10,6 +10,7 @@ OEM_MNT="/usr/share/oem"
 
 INSTALL_MNT=$(dirname "$0")
 INSTALL_DEV="$1"
+APP_ID="${2:-{e96281a6-d1af-4bde-9a0a-97b76e56dc57}}"
 
 # Figure out if the slot id is A or B
 INSTALL_LABEL=$(lsblk -n -o PARTLABEL "${INSTALL_DEV}")
@@ -78,11 +79,14 @@ if grep -q cros_legacy /proc/cmdline; then
     fi
 fi
 
-# Copy the kernel to the ESP for new-style boots
-if [[ -f "${ESP_MNT}/coreos/vmlinuz-a" ]]; then
-    # kernel names are in lower case, ${SLOT,,} converts the slot name
-    cp -v "${INSTALL_MNT}/boot/vmlinuz" \
-       "${ESP_MNT}/coreos/vmlinuz-${SLOT,,}"
+# Check if we're running on an old-style app config
+if [[ "$APP_ID" = "{e96281a6-d1af-4bde-9a0a-97b76e56dc57}" ]]; then
+    # Copy the kernel to the ESP for new-style boots
+    if [[ -f "${ESP_MNT}/coreos/vmlinuz-a" ]]; then
+	# kernel names are in lower case, ${SLOT,,} converts the slot name
+	cp -v "${INSTALL_MNT}/boot/vmlinuz" \
+	   "${ESP_MNT}/coreos/vmlinuz-${SLOT,,}"
+    fi
 fi
 
 # If the OEM provides a hook, call it

--- a/src/update_engine/delta_performer.cc
+++ b/src/update_engine/delta_performer.cc
@@ -839,16 +839,19 @@ bool DeltaPerformer::GetNewPartitionInfo(uint64_t* kernel_size,
                                          uint64_t* rootfs_size,
                                          vector<char>* rootfs_hash) {
   TEST_AND_RETURN_FALSE(manifest_valid_ &&
-                        manifest_.has_new_kernel_info() &&
-                        manifest_.has_new_rootfs_info());
-  *kernel_size = manifest_.new_kernel_info().size();
+			manifest_.has_new_rootfs_info());
   *rootfs_size = manifest_.new_rootfs_info().size();
-  vector<char> new_kernel_hash(manifest_.new_kernel_info().hash().begin(),
-                               manifest_.new_kernel_info().hash().end());
   vector<char> new_rootfs_hash(manifest_.new_rootfs_info().hash().begin(),
                                manifest_.new_rootfs_info().hash().end());
-  kernel_hash->swap(new_kernel_hash);
   rootfs_hash->swap(new_rootfs_hash);
+
+  if (manifest_.has_new_kernel_info()) {
+    *kernel_size = manifest_.new_kernel_info().size();
+    vector<char> new_kernel_hash(manifest_.new_kernel_info().hash().begin(),
+				 manifest_.new_kernel_info().hash().end());
+    kernel_hash->swap(new_kernel_hash);
+  }
+      
   return true;
 }
 

--- a/src/update_engine/delta_performer.h
+++ b/src/update_engine/delta_performer.h
@@ -206,13 +206,13 @@ class DeltaPerformer : public FileWriter {
   // These perform a specific type of operation and return true on success.
   bool PerformReplaceOperation(
       const DeltaArchiveManifest_InstallOperation& operation,
-      bool is_kernel_partition);
+      bool is_kernel);
   bool PerformMoveOperation(
       const DeltaArchiveManifest_InstallOperation& operation,
-      bool is_kernel_partition);
+      bool is_kernel);
   bool PerformBsdiffOperation(
       const DeltaArchiveManifest_InstallOperation& operation,
-      bool is_kernel_partition);
+      bool is_kernel);
 
   // Returns true if the payload signature message has been extracted from
   // |operation|, false otherwise.

--- a/src/update_engine/download_action.cc
+++ b/src/update_engine/download_action.cc
@@ -60,7 +60,15 @@ void DownloadAction::PerformAction() {
     processor_->ActionComplete(this, kActionCodeInstallDeviceOpenError);
     return;
   }
-
+  if (delta_performer_.get() &&
+      !delta_performer_->OpenKernel(
+          install_plan_.kernel_install_path.c_str())) {
+    LOG(ERROR) << "Unable to open kernel file "
+               << install_plan_.kernel_install_path;
+    writer_->Close();
+    processor_->ActionComplete(this, kActionCodeKernelDeviceOpenError);
+    return;
+  }
   if (delegate_) {
     delegate_->SetDownloadStatus(true);  // Set to active.
   }

--- a/src/update_engine/filesystem_copier_action.cc
+++ b/src/update_engine/filesystem_copier_action.cc
@@ -283,7 +283,8 @@ void FilesystemCopierAction::SpawnAsyncActions() {
       LOG(INFO) << "Hash: " << hasher_.hash();
       if (verify_hash_) {
         if (copying_kernel_install_path_) {
-          if (install_plan_.kernel_hash != hasher_.raw_hash()) {
+          if (install_plan_.kernel_size &&
+	      (install_plan_.kernel_hash != hasher_.raw_hash())) {
             code = kActionCodeNewKernelVerificationError;
             LOG(ERROR) << "New kernel verification failed.";
           }

--- a/src/update_engine/filesystem_copier_action.cc
+++ b/src/update_engine/filesystem_copier_action.cc
@@ -83,7 +83,7 @@ void FilesystemCopierAction::PerformAction() {
   string source = verify_hash_ ? destination : copy_source_;
   if (source.empty()) {
     source = copying_kernel_install_path_ ?
-        utils::BootKernelDevice(utils::BootDevice()) :
+        utils::BootKernelName(utils::BootDevice()) :
         utils::BootDevice();
   }
   int src_fd = open(source.c_str(), O_RDONLY);

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -63,7 +63,7 @@ void OmahaResponseHandlerAction::PerformAction() {
       (!boot_device_.empty() ? boot_device_ : utils::BootDevice()),
       &install_plan_.install_path));
   install_plan_.kernel_install_path =
-      utils::BootKernelDevice(install_plan_.install_path);
+      utils::BootKernelName(install_plan_.install_path);
 
   TEST_AND_RETURN(HasOutputPipe());
   if (HasOutputPipe())
@@ -91,8 +91,7 @@ bool OmahaResponseHandlerAction::GetInstallDev(const std::string& boot_dev,
   TEST_AND_RETURN_FALSE(utils::StringHasPrefix(boot_dev, "/dev/"));
   string ret(boot_dev);
   string::reverse_iterator it = ret.rbegin();  // last character in string
-  // Right now, we just switch '3' and '5' partition numbers.
-  // TODOBP: Make this read in the partition table and do it from there
+  // Right now, we just switch '3' and '4' partition numbers.
   TEST_AND_RETURN_FALSE((*it == '3') || (*it == '4'));
   *it = (*it == '3') ? '4' : '3';
   *install_dev = ret;

--- a/src/update_engine/postinstall_runner_action.cc
+++ b/src/update_engine/postinstall_runner_action.cc
@@ -18,6 +18,10 @@ namespace {
 const char kPostinstallScript[] = "/postinst";
 }
 
+PostinstallRunnerAction::PostinstallRunnerAction(
+    std::string app_id)
+    : app_id_(std::move(app_id)) {}
+
 void PostinstallRunnerAction::PerformAction() {
   CHECK(HasInputObject());
   const InstallPlan install_plan = GetInputObject();
@@ -57,6 +61,7 @@ void PostinstallRunnerAction::PerformAction() {
   vector<string> command;
   command.push_back(temp_rootfs_dir_ + kPostinstallScript);
   command.push_back(install_device);
+  command.push_back(app_id_);
   if (!Subprocess::Get().Exec(command, StaticCompletePostinstall, this)) {
     CompletePostinstall(1);
   }

--- a/src/update_engine/postinstall_runner_action.h
+++ b/src/update_engine/postinstall_runner_action.h
@@ -29,7 +29,7 @@ class ActionTraits<PostinstallRunnerAction> {
 
 class PostinstallRunnerAction : public Action<PostinstallRunnerAction> {
  public:
-  PostinstallRunnerAction() {}
+  explicit PostinstallRunnerAction(std::string app_id);
   typedef ActionTraits<PostinstallRunnerAction>::InputObjectType
       InputObjectType;
   typedef ActionTraits<PostinstallRunnerAction>::OutputObjectType
@@ -51,6 +51,7 @@ class PostinstallRunnerAction : public Action<PostinstallRunnerAction> {
                                         void* p);
 
   std::string temp_rootfs_dir_;
+  std::string app_id_;
 
   DISALLOW_COPY_AND_ASSIGN(PostinstallRunnerAction);
 };

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -204,7 +204,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   shared_ptr<FilesystemCopierAction> kernel_filesystem_verifier_action(
       new FilesystemCopierAction(true, true));
   shared_ptr<PostinstallRunnerAction> postinstall_runner_action(
-      new PostinstallRunnerAction);
+      new PostinstallRunnerAction(omaha_request_params_->app_id()));
   shared_ptr<OmahaRequestAction> update_complete_action(
       new OmahaRequestAction(system_state_,
                              new OmahaEvent(OmahaEvent::kTypeUpdateComplete),

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -218,10 +218,14 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   actions_.push_back(shared_ptr<AbstractAction>(update_check_action));
   actions_.push_back(shared_ptr<AbstractAction>(response_handler_action));
   actions_.push_back(shared_ptr<AbstractAction>(filesystem_copier_action));
+  actions_.push_back(shared_ptr<AbstractAction>(
+      kernel_filesystem_copier_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_started_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_finished_action));
   actions_.push_back(shared_ptr<AbstractAction>(filesystem_verifier_action));
+  actions_.push_back(shared_ptr<AbstractAction>(
+      kernel_filesystem_verifier_action));
   actions_.push_back(shared_ptr<AbstractAction>(postinstall_runner_action));
   actions_.push_back(shared_ptr<AbstractAction>(update_complete_action));
 
@@ -237,10 +241,14 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   BondActions(response_handler_action.get(),
               filesystem_copier_action.get());
   BondActions(filesystem_copier_action.get(),
+              kernel_filesystem_copier_action.get());
+  BondActions(kernel_filesystem_copier_action.get(),
               download_action.get());
   BondActions(download_action.get(),
               filesystem_verifier_action.get());
   BondActions(filesystem_verifier_action.get(),
+              kernel_filesystem_verifier_action.get());
+  BondActions(kernel_filesystem_verifier_action.get(),
               postinstall_runner_action.get());
 }
 

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -484,17 +484,15 @@ const std::string BootDevice() {
   return boot_path;
 }
 
-const string BootKernelDevice(const std::string& boot_device) {
-  // Currntly this assumes the last digit of the boot device is
-  // 3, 5, or 7, and changes it to 2, 4, or 6, respectively, to
-  // get the kernel device.
-  string ret = boot_device;
-  if (ret.empty())
-    return ret;
-  char last_char = ret[ret.size() - 1];
-  if (last_char == '3' || last_char == '5' || last_char == '7') {
-    ret[ret.size() - 1] = last_char - 1;
-    return ret;
+const string BootKernelName(const std::string& boot_device) {
+  // If the target fs is 3, the kernel name is vmlinuz-a.
+  // If the target fs is 4, the kernel name is vmlinuz-b.
+  char last_char = boot_device[boot_device.size() - 1];
+  if (last_char == '3') {
+    return "/boot/coreos/vmlinuz-a";
+  }
+  if (last_char == '4') {
+    return "/boot/coreos/vmlinuz-b";
   }
   return "";
 }

--- a/src/update_engine/utils.h
+++ b/src/update_engine/utils.h
@@ -228,12 +228,11 @@ void ApplyMap(std::vector<ValueType>* collection,
 // or something with equivalent funcionality to interpret those.
 const std::string BootDevice();
 
-// Returns the currently booted kernel device, "dev/sda2", for example.
+// Returns the currently booted kernel name, "/boot/coreos/vmlinuz-a", for example.
 // Client must pass in the boot device. The suggested calling convention
 // is: BootKernelDevice(BootDevice()).
-// This function works by doing string modification on boot_device.
 // Returns empty string on failure.
-const std::string BootKernelDevice(const std::string& boot_device);
+const std::string BootKernelName(const std::string& boot_device);
 
 // Assumes data points to a Closure. Runs it and returns FALSE;
 gboolean GlibRunClosure(gpointer data);


### PR DESCRIPTION
Distributing the kernel outside the filesystem is necessary for the combination of Secure Boot and verified filesystems, so we need Update Engine to be able to handle update images that contain a separate kernel payload and copy it to the right place.