### PR TITLE
utils: remove support for ChromeOS "dev mode"

### DIFF
--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -494,9 +494,6 @@ void UpdateAttempter::BroadcastStatus() {
 uint32_t UpdateAttempter::GetErrorCodeFlags()  {
   uint32_t flags = 0;
 
-  if (!utils::IsNormalBootMode())
-    flags |= kActionCodeDevModeFlag;
-
   if (response_handler_action_.get() &&
       response_handler_action_->install_plan().is_resume)
     flags |= kActionCodeResumedFlag;

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -64,21 +64,6 @@ bool IsOfficialBuild() {
   return !file_util::PathExists(FilePath(kDevImageMarker));
 }
 
-bool IsNormalBootMode() {
-  // TODO(petkov): Convert to a library call once a crossystem library is
-  // available (crosbug.com/13291).
-  int exit_code = 0;
-  vector<string> cmd(1, "/usr/bin/crossystem");
-  cmd.push_back("devsw_boot?1");
-
-  // Assume dev mode if the dev switch is set to 1 and there was no error
-  // executing crossystem. Assume normal mode otherwise.
-  bool success = Subprocess::SynchronousExec(cmd, &exit_code, NULL);
-  bool dev_mode = success && exit_code == 0;
-  LOG_IF(INFO, dev_mode) << "Booted in dev mode.";
-  return !dev_mode;
-}
-
 string GetBootId() {
   string id;
   string guid;

--- a/src/update_engine/utils.h
+++ b/src/update_engine/utils.h
@@ -29,10 +29,6 @@ namespace utils {
 // Returns true if this is an official Chrome OS build, false otherwise.
 bool IsOfficialBuild();
 
-// Returns true if the boot mode is normal or if it's unable to determine the
-// boot mode. Returns false if the boot mode is developer.
-bool IsNormalBootMode();
-
 // Returns the HWID or an empty string on error.
 std::string GetHardwareClass();
 

--- a/src/update_engine/utils_unittest.cc
+++ b/src/update_engine/utils_unittest.cc
@@ -31,11 +31,6 @@ TEST(UtilsTest, IsOfficialBuild) {
   EXPECT_TRUE(utils::IsOfficialBuild());
 }
 
-TEST(UtilsTest, IsNormalBootMode) {
-  // Pretty lame test...
-  EXPECT_TRUE(utils::IsNormalBootMode());
-}
-
 TEST(UtilsTest, NormalizePathTest) {
   EXPECT_EQ("", utils::NormalizePath("", false));
   EXPECT_EQ("", utils::NormalizePath("", true));


### PR DESCRIPTION
update_engine is the only remaining user of the tool 'crossystem' which
does not provide any useful functionality on CoreOS. This particular
check was for whether the physical "dev mode" switch on a ChromeBook had
been enabled.