### PR TITLE
Fix updates with no kernel image

### DIFF
--- a/src/update_engine/delta_performer.h
+++ b/src/update_engine/delta_performer.h
@@ -76,7 +76,7 @@ class DeltaPerformer : public FileWriter {
 
   // Opens the kernel. Should be called before or after Open(), but before
   // Write(). The kernel file will be close()d when Close() is called.
-  bool OpenKernel(const char* kernel_path);
+  int OpenKernel(const char* kernel_path);
 
   // flags and mode ignored. Once Close()d, a DeltaPerformer can't be
   // Open()ed again.

--- a/src/update_engine/delta_performer_unittest.cc
+++ b/src/update_engine/delta_performer_unittest.cc
@@ -491,7 +491,7 @@ static void ApplyDeltaFile(bool full_kernel, bool full_rootfs, bool noop,
                                                  &install_plan.kernel_hash));
 
   EXPECT_EQ(0, (*performer)->Open(state->a_img.c_str(), 0, 0));
-  EXPECT_TRUE((*performer)->OpenKernel(state->old_kernel.c_str()));
+  EXPECT_EQ(0, (*performer)->OpenKernel(state->old_kernel.c_str()));
 
   ActionExitCode expected_error, actual_error;
   bool continue_writing;
@@ -712,7 +712,7 @@ TEST(DeltaPerformerTest, BadDeltaMagicTest) {
   MockSystemState mock_system_state;
   DeltaPerformer performer(&prefs, &mock_system_state, &install_plan);
   EXPECT_EQ(0, performer.Open("/dev/null", 0, 0));
-  EXPECT_TRUE(performer.OpenKernel("/dev/null"));
+  EXPECT_EQ(0, performer.OpenKernel("/dev/null"));
   EXPECT_TRUE(performer.Write("junk", 4));
   EXPECT_TRUE(performer.Write("morejunk", 8));
   EXPECT_FALSE(performer.Write("morejunk", 8));
@@ -741,7 +741,7 @@ TEST(DeltaPerformerTest, WriteUpdatesPayloadState) {
   MockSystemState mock_system_state;
   DeltaPerformer performer(&prefs, &mock_system_state, &install_plan);
   EXPECT_EQ(0, performer.Open("/dev/null", 0, 0));
-  EXPECT_TRUE(performer.OpenKernel("/dev/null"));
+  EXPECT_EQ(0, performer.OpenKernel("/dev/null"));
 
   EXPECT_CALL(*(mock_system_state.mock_payload_state()),
               DownloadProgress(4)).Times(1);

--- a/src/update_engine/download_action.cc
+++ b/src/update_engine/download_action.cc
@@ -45,29 +45,20 @@ void DownloadAction::PerformAction() {
 
   if (writer_) {
     LOG(INFO) << "Using writer for test.";
+    int rc = writer_->Open(install_plan_.install_path.c_str(),
+			   O_TRUNC | O_WRONLY | O_CREAT | O_LARGEFILE,
+			   0644);
+    if (rc < 0) {
+      LOG(ERROR) << "Unable to open output file " << install_plan_.install_path;
+      // report error to processor
+      processor_->ActionComplete(this, kActionCodeInstallDeviceOpenError);
+      return;
+    }    
   } else {
     delta_performer_.reset(new DeltaPerformer(prefs_,
                                               system_state_,
                                               &install_plan_));
     writer_ = delta_performer_.get();
-  }
-  int rc = writer_->Open(install_plan_.install_path.c_str(),
-                         O_TRUNC | O_WRONLY | O_CREAT | O_LARGEFILE,
-                         0644);
-  if (rc < 0) {
-    LOG(ERROR) << "Unable to open output file " << install_plan_.install_path;
-    // report error to processor
-    processor_->ActionComplete(this, kActionCodeInstallDeviceOpenError);
-    return;
-  }
-  if (delta_performer_.get() &&
-      !delta_performer_->OpenKernel(
-          install_plan_.kernel_install_path.c_str())) {
-    LOG(ERROR) << "Unable to open kernel file "
-               << install_plan_.kernel_install_path;
-    writer_->Close();
-    processor_->ActionComplete(this, kActionCodeKernelDeviceOpenError);
-    return;
   }
   if (delegate_) {
     delegate_->SetDownloadStatus(true);  // Set to active.

--- a/src/update_engine/filesystem_copier_action.cc
+++ b/src/update_engine/filesystem_copier_action.cc
@@ -77,6 +77,14 @@ void FilesystemCopierAction::PerformAction() {
     return;
   }
 
+  if (copying_kernel_install_path_ && !install_plan_.kernel_size) {
+    // No kernel to install
+    if (HasOutputPipe())
+      SetOutputObject(install_plan_);
+    abort_action_completer.set_code(kActionCodeSuccess);
+    return;
+  }
+
   const string destination = copying_kernel_install_path_ ?
       install_plan_.kernel_install_path :
       install_plan_.install_path;

--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -195,7 +195,7 @@ void ApplyDelta() {
                                   root_info.hash().end());
   DeltaPerformer performer(&prefs, NULL, &install_plan);
   CHECK_EQ(performer.Open(FLAGS_old_image.c_str(), 0, 0), 0);
-  CHECK(performer.OpenKernel(FLAGS_old_kernel.c_str()));
+  CHECK_EQ(performer.OpenKernel(FLAGS_old_kernel.c_str()), 0);
   vector<char> buf(1024 * 1024);
   int fd = open(FLAGS_in_file.c_str(), O_RDONLY, 0);
   CHECK_GE(fd, 0);


### PR DESCRIPTION
Right now if we get an update that contains no kernel, we'll still set up
the FileCopierAction for the kernel and try to run it. This will break if
the installed image doesn't contain kernels in the new location. Just exit
early to avoid that from happening.