### PR TITLE
Remove old kernel update code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@
 # Build/test generated files
 *.gcda
 *.gcno
+.deps/
+.dirstamp
 /*.pub.pem
-/.deps/
 /Makefile
 /Makefile.in
 /aclocal.m4

--- a/coreos-postinst
+++ b/coreos-postinst
@@ -10,7 +10,7 @@ OEM_MNT="/usr/share/oem"
 
 INSTALL_MNT=$(dirname "$0")
 INSTALL_DEV="$1"
-APP_ID="${2:-{e96281a6-d1af-4bde-9a0a-97b76e56dc57}}"
+APP_ID="${2:-"{e96281a6-d1af-4bde-9a0a-97b76e56dc57}"}"
 
 # Figure out if the slot id is A or B
 INSTALL_LABEL=$(lsblk -n -o PARTLABEL "${INSTALL_DEV}")
@@ -139,8 +139,6 @@ call_cgpt add -S0 -T1 "${INSTALL_DEV}"
 call_cgpt prioritize "${INSTALL_DEV}"
 call_cgpt show "${INSTALL_DEV}"
 
-grep ^COREOS_RELEASE_VERSION "${INSTALL_MNT}/share/coreos/release" || \
-    grep ^COREOS_RELEASE_VERSION "${INSTALL_MNT}/etc/lsb-release" || \
-    echo "Unknown COREOS_RELEASE_VERSION" >&2
-
+cat "${INSTALL_MNT}/share/coreos/release"
+echo "COREOS_RELEASE_APPID=$APP_ID"
 echo "Setup ${INSTALL_LABEL} (${INSTALL_DEV}) for next boot."

--- a/src/update_engine/delta_diff_generator.h
+++ b/src/update_engine/delta_diff_generator.h
@@ -56,8 +56,6 @@ class DeltaDiffGenerator {
   // This is the only function that external users of the class should call.
   // old_image and new_image are paths to two image files. They should be
   // mounted read-only at paths old_root and new_root respectively.
-  // {old,new}_kernel_part are paths to the old and new kernel partition
-  // images, respectively.
   // private_key_path points to a private key used to sign the update.
   // Pass empty string to not sign the update.
   // output_path is the filename where the delta update should be written.
@@ -67,8 +65,6 @@ class DeltaDiffGenerator {
                                       const std::string& old_image,
                                       const std::string& new_root,
                                       const std::string& new_image,
-                                      const std::string& old_kernel_part,
-                                      const std::string& new_kernel_part,
                                       const std::string& output_path,
                                       const std::string& private_key_path,
                                       uint64_t* metadata_size);
@@ -221,8 +217,7 @@ class DeltaDiffGenerator {
   // (e.g., a move operation that copies blocks onto themselves).
   static bool IsNoopOperation(const DeltaArchiveManifest_InstallOperation& op);
 
-  static bool InitializePartitionInfo(bool is_kernel,
-                                      const std::string& partition,
+  static bool InitializePartitionInfo(const std::string& partition,
                                       PartitionInfo* info);
 
   // Runs the bsdiff tool on two files and returns the resulting delta in

--- a/src/update_engine/delta_performer.cc
+++ b/src/update_engine/delta_performer.cc
@@ -351,7 +351,7 @@ bool DeltaPerformer::Write(const void* bytes, size_t count,
 
     num_rootfs_operations_ = manifest_.install_operations_size();
     num_total_operations_ =
-        num_rootfs_operations_ + manifest_.kernel_install_operations_size();
+        num_rootfs_operations_ + manifest_.noop_operations_size();
     if (next_operation_num_ > 0)
       UpdateOverallProgress(true, "Resuming after ");
     LOG(INFO) << "Starting to apply update payload operations";
@@ -377,7 +377,7 @@ bool DeltaPerformer::Write(const void* bytes, size_t count,
 
     const DeltaArchiveManifest_InstallOperation &op =
         is_kernel ?
-        manifest_.kernel_install_operations(
+        manifest_.noop_operations(
             next_operation_num_ - num_rootfs_operations_) :
         manifest_.install_operations(next_operation_num_);
     if (!CanPerformInstallOperation(op)) {

--- a/src/update_engine/delta_performer.cc
+++ b/src/update_engine/delta_performer.cc
@@ -191,19 +191,8 @@ int DeltaPerformer::Open(const char* path, int flags, mode_t mode) {
   return -err;
 }
 
-int DeltaPerformer::OpenKernel(const char* kernel_path) {
-  int err;
-  if (OpenFile(kernel_path, &kernel_fd_, &err))
-    kernel_path_ = kernel_path;
-  return -err;
-}
-
 int DeltaPerformer::Close() {
   int err = 0;
-  if (close(kernel_fd_) == -1) {
-    err = errno;
-    PLOG(ERROR) << "Unable to close kernel fd:";
-  }
   if (close(fd_) == -1) {
     err = errno;
     PLOG(ERROR) << "Unable to close rootfs fd:";
@@ -235,12 +224,8 @@ void LogPartitionInfoHash(const PartitionInfo& info, const string& tag) {
 }
 
 void LogPartitionInfo(const DeltaArchiveManifest& manifest) {
-  if (manifest.has_old_kernel_info())
-    LogPartitionInfoHash(manifest.old_kernel_info(), "old_kernel_info");
   if (manifest.has_old_rootfs_info())
     LogPartitionInfoHash(manifest.old_rootfs_info(), "old_rootfs_info");
-  if (manifest.has_new_kernel_info())
-    LogPartitionInfoHash(manifest.new_kernel_info(), "new_kernel_info");
   if (manifest.has_new_rootfs_info())
     LogPartitionInfoHash(manifest.new_rootfs_info(), "new_rootfs_info");
 }
@@ -358,15 +343,7 @@ bool DeltaPerformer::Write(const void* bytes, size_t count,
   }
 
   while (next_operation_num_ < num_total_operations_) {
-    const bool is_kernel =
-        (next_operation_num_ >= num_rootfs_operations_);
-
-    if (is_kernel && kernel_fd_ == -1) {
-      if (OpenKernel(install_plan_->kernel_install_path.c_str()) < 0) {
-	LOG(ERROR) << "Unable to open output file " << install_plan_->kernel_install_path;
-	return false;
-      }
-    } else if (fd_ == -1) {
+    if (fd_ == -1) {
       if (Open(install_plan_->install_path.c_str(),
 	       O_TRUNC | O_WRONLY | O_CREAT | O_LARGEFILE,
 	       0644) < 0) {
@@ -375,8 +352,10 @@ bool DeltaPerformer::Write(const void* bytes, size_t count,
       }
     }
 
+    const bool is_noop =
+        (next_operation_num_ >= num_rootfs_operations_);
     const DeltaArchiveManifest_InstallOperation &op =
-        is_kernel ?
+        is_noop ?
         manifest_.noop_operations(
             next_operation_num_ - num_rootfs_operations_) :
         manifest_.install_operations(next_operation_num_);
@@ -401,27 +380,30 @@ bool DeltaPerformer::Write(const void* bytes, size_t count,
       *error = kActionCodeSuccess;
     }
 
+    // TODO(marineam): Add a PerformNoopOperation and call it here instead
+    // of assuming PerformReplaceOperation will safely noop.
+
     // Makes sure we unblock exit when this operation completes.
     ScopedTerminatorExitUnblocker exit_unblocker =
         ScopedTerminatorExitUnblocker();  // Avoids a compiler unused var bug.
     // Log every thousandth operation, and also the first and last ones
     if (op.type() == DeltaArchiveManifest_InstallOperation_Type_REPLACE ||
         op.type() == DeltaArchiveManifest_InstallOperation_Type_REPLACE_BZ) {
-      if (!PerformReplaceOperation(op, is_kernel)) {
+      if (!PerformReplaceOperation(op)) {
         LOG(ERROR) << "Failed to perform replace operation "
                    << next_operation_num_;
         *error = kActionCodeDownloadOperationExecutionError;
         return false;
       }
     } else if (op.type() == DeltaArchiveManifest_InstallOperation_Type_MOVE) {
-      if (!PerformMoveOperation(op, is_kernel)) {
+      if (!PerformMoveOperation(op)) {
         LOG(ERROR) << "Failed to perform move operation "
                    << next_operation_num_;
         *error = kActionCodeDownloadOperationExecutionError;
         return false;
       }
     } else if (op.type() == DeltaArchiveManifest_InstallOperation_Type_BSDIFF) {
-      if (!PerformBsdiffOperation(op, is_kernel)) {
+      if (!PerformBsdiffOperation(op)) {
         LOG(ERROR) << "Failed to perform bsdiff operation "
                    << next_operation_num_;
         *error = kActionCodeDownloadOperationExecutionError;
@@ -455,8 +437,7 @@ bool DeltaPerformer::CanPerformInstallOperation(
 }
 
 bool DeltaPerformer::PerformReplaceOperation(
-    const DeltaArchiveManifest_InstallOperation& operation,
-    bool is_kernel) {
+    const DeltaArchiveManifest_InstallOperation& operation) {
   CHECK(operation.type() == \
         DeltaArchiveManifest_InstallOperation_Type_REPLACE || \
         operation.type() == \
@@ -478,18 +459,10 @@ bool DeltaPerformer::PerformReplaceOperation(
   // point to one of the ExtentWriter objects above.
   ExtentWriter* writer = NULL;
   if (operation.type() == DeltaArchiveManifest_InstallOperation_Type_REPLACE) {
-    if (is_kernel) {
-      writer = &direct_writer;
-    } else {
-      writer = &zero_pad_writer;
-    }
+    writer = &zero_pad_writer;
   } else if (operation.type() ==
              DeltaArchiveManifest_InstallOperation_Type_REPLACE_BZ) {
-    if (is_kernel) {
-      bzip_writer.reset(new BzipExtentWriter(&direct_writer));
-    } else {
-      bzip_writer.reset(new BzipExtentWriter(&zero_pad_writer));
-    }
+    bzip_writer.reset(new BzipExtentWriter(&zero_pad_writer));
     writer = bzip_writer.get();
   } else {
     NOTREACHED();
@@ -501,9 +474,7 @@ bool DeltaPerformer::PerformReplaceOperation(
     extents.push_back(operation.dst_extents(i));
   }
 
-  int fd = is_kernel ? kernel_fd_ : fd_;
-
-  TEST_AND_RETURN_FALSE(writer->Init(fd, extents, block_size_));
+  TEST_AND_RETURN_FALSE(writer->Init(fd_, extents, block_size_));
   TEST_AND_RETURN_FALSE(writer->Write(&buffer_[0], operation.data_length()));
   TEST_AND_RETURN_FALSE(writer->End());
   // Update buffer
@@ -513,8 +484,7 @@ bool DeltaPerformer::PerformReplaceOperation(
 }
 
 bool DeltaPerformer::PerformMoveOperation(
-    const DeltaArchiveManifest_InstallOperation& operation,
-    bool is_kernel) {
+    const DeltaArchiveManifest_InstallOperation& operation) {
   // Calculate buffer size. Note, this function doesn't do a sliding
   // window to copy in case the source and destination blocks overlap.
   // If we wanted to do a sliding window, we could program the server
@@ -531,14 +501,12 @@ bool DeltaPerformer::PerformMoveOperation(
   DCHECK_EQ(blocks_to_write, blocks_to_read);
   vector<char> buf(blocks_to_write * block_size_);
 
-  int fd = is_kernel ? kernel_fd_ : fd_;
-
   // Read in bytes.
   ssize_t bytes_read = 0;
   for (int i = 0; i < operation.src_extents_size(); i++) {
     ssize_t bytes_read_this_iteration = 0;
     const Extent& extent = operation.src_extents(i);
-    TEST_AND_RETURN_FALSE(utils::PReadAll(fd,
+    TEST_AND_RETURN_FALSE(utils::PReadAll(fd_,
                                           &buf[bytes_read],
                                           extent.num_blocks() * block_size_,
                                           extent.start_block() * block_size_,
@@ -561,7 +529,7 @@ bool DeltaPerformer::PerformMoveOperation(
   ssize_t bytes_written = 0;
   for (int i = 0; i < operation.dst_extents_size(); i++) {
     const Extent& extent = operation.dst_extents(i);
-    TEST_AND_RETURN_FALSE(utils::PWriteAll(fd,
+    TEST_AND_RETURN_FALSE(utils::PWriteAll(fd_,
                                            &buf[bytes_written],
                                            extent.num_blocks() * block_size_,
                                            extent.start_block() * block_size_));
@@ -599,8 +567,7 @@ bool DeltaPerformer::ExtentsToBsdiffPositionsString(
 }
 
 bool DeltaPerformer::PerformBsdiffOperation(
-    const DeltaArchiveManifest_InstallOperation& operation,
-    bool is_kernel) {
+    const DeltaArchiveManifest_InstallOperation& operation) {
   // Since we delete data off the beginning of the buffer as we use it,
   // the data we need should be exactly at the beginning of the buffer.
   TEST_AND_RETURN_FALSE(buffer_offset_ == operation.data_offset());
@@ -629,8 +596,7 @@ bool DeltaPerformer::PerformBsdiffOperation(
         utils::WriteAll(fd, &buffer_[0], operation.data_length()));
   }
 
-  int fd = is_kernel ? kernel_fd_ : fd_;
-  const string& path = StringPrintf("/dev/fd/%d", fd);
+  const string& path = StringPrintf("/dev/fd/%d", fd_);
 
   // If this is a non-idempotent operation, request a delayed exit and clear the
   // update state in case the operation gets interrupted. Do this as late as
@@ -666,7 +632,7 @@ bool DeltaPerformer::PerformBsdiffOperation(
         end_byte - (block_size_ - operation.dst_length() % block_size_);
     vector<char> zeros(end_byte - begin_byte);
     TEST_AND_RETURN_FALSE(
-        utils::PWriteAll(fd, &zeros[0], end_byte - begin_byte, begin_byte));
+        utils::PWriteAll(fd_, &zeros[0], end_byte - begin_byte, begin_byte));
   }
 
   // Update buffer.
@@ -848,9 +814,7 @@ ActionExitCode DeltaPerformer::VerifyPayload(
   return kActionCodeSuccess;
 }
 
-bool DeltaPerformer::GetNewPartitionInfo(uint64_t* kernel_size,
-                                         vector<char>* kernel_hash,
-                                         uint64_t* rootfs_size,
+bool DeltaPerformer::GetNewPartitionInfo(uint64_t* rootfs_size,
                                          vector<char>* rootfs_hash) {
   TEST_AND_RETURN_FALSE(manifest_valid_ &&
 			manifest_.has_new_rootfs_info());
@@ -858,22 +822,13 @@ bool DeltaPerformer::GetNewPartitionInfo(uint64_t* kernel_size,
   vector<char> new_rootfs_hash(manifest_.new_rootfs_info().hash().begin(),
                                manifest_.new_rootfs_info().hash().end());
   rootfs_hash->swap(new_rootfs_hash);
-
-  if (manifest_.has_new_kernel_info()) {
-    *kernel_size = manifest_.new_kernel_info().size();
-    vector<char> new_kernel_hash(manifest_.new_kernel_info().hash().begin(),
-				 manifest_.new_kernel_info().hash().end());
-    kernel_hash->swap(new_kernel_hash);
-  }
-      
   return true;
 }
 
 namespace {
-void LogVerifyError(bool is_kern,
-                    const string& local_hash,
+void LogVerifyError(const string& local_hash,
                     const string& expected_hash) {
-  const char* type = is_kern ? "kernel" : "rootfs";
+  const char* type = "rootfs";
   LOG(ERROR) << "This is a server-side error due to "
              << "mismatched delta update image!";
   LOG(ERROR) << "The delta I've been given contains a " << type << " delta "
@@ -884,19 +839,12 @@ void LogVerifyError(bool is_kern,
              << "system. The " << type << " partition I have has hash: "
              << local_hash << " but the update expected me to have "
              << expected_hash << " .";
-  if (is_kern) {
-    LOG(INFO) << "To get the checksum of a kernel partition on a "
-              << "booted machine, run this command (change /dev/sda2 "
-              << "as needed): dd if=/dev/sda2 bs=1M 2>/dev/null | "
-              << "openssl dgst -sha256 -binary | openssl base64";
-  } else {
-    LOG(INFO) << "To get the checksum of a rootfs partition on a "
-              << "booted machine, run this command (change /dev/sda3 "
-              << "as needed): dd if=/dev/sda3 bs=1M count=$(( "
-              << "$(dumpe2fs /dev/sda3  2>/dev/null | grep 'Block count' "
-              << "| sed 's/[^0-9]*//') / 256 )) | "
-              << "openssl dgst -sha256 -binary | openssl base64";
-  }
+  LOG(INFO) << "To get the checksum of a rootfs partition on a "
+            << "booted machine, run this command (change /dev/sda3 "
+            << "as needed): dd if=/dev/sda3 bs=1M count=$(( "
+            << "$(dumpe2fs /dev/sda3  2>/dev/null | grep 'Block count' "
+            << "| sed 's/[^0-9]*//') / 256 )) | "
+            << "openssl dgst -sha256 -binary | openssl base64";
   LOG(INFO) << "To get the checksum of partitions in a bin file, "
             << "run: .../src/scripts/sha256_partitions.sh .../file.bin";
 }
@@ -910,27 +858,10 @@ string StringForHashBytes(const void* bytes, size_t size) {
 }
 }  // namespace
 
-bool DeltaPerformer::VerifySourcePartitions() {
-  LOG(INFO) << "Verifying source partitions.";
+bool DeltaPerformer::VerifySourcePartition() {
+  LOG(INFO) << "Verifying source partition.";
   CHECK(manifest_valid_);
   CHECK(install_plan_);
-  if (manifest_.has_old_kernel_info()) {
-    const PartitionInfo& info = manifest_.old_kernel_info();
-    bool valid =
-        !install_plan_->kernel_hash.empty() &&
-        install_plan_->kernel_hash.size() == info.hash().size() &&
-        memcmp(install_plan_->kernel_hash.data(),
-               info.hash().data(),
-               install_plan_->kernel_hash.size()) == 0;
-    if (!valid) {
-      LogVerifyError(true,
-                     StringForHashBytes(install_plan_->kernel_hash.data(),
-                                        install_plan_->kernel_hash.size()),
-                     StringForHashBytes(info.hash().data(),
-                                        info.hash().size()));
-    }
-    TEST_AND_RETURN_FALSE(valid);
-  }
   if (manifest_.has_old_rootfs_info()) {
     const PartitionInfo& info = manifest_.old_rootfs_info();
     bool valid =
@@ -940,8 +871,7 @@ bool DeltaPerformer::VerifySourcePartitions() {
                info.hash().data(),
                install_plan_->rootfs_hash.size()) == 0;
     if (!valid) {
-      LogVerifyError(false,
-                     StringForHashBytes(install_plan_->rootfs_hash.data(),
+      LogVerifyError(StringForHashBytes(install_plan_->rootfs_hash.data(),
                                         install_plan_->rootfs_hash.size()),
                      StringForHashBytes(info.hash().data(),
                                         info.hash().size()));
@@ -1035,7 +965,7 @@ bool DeltaPerformer::PrimeUpdateState() {
       next_operation == kUpdateStateOperationInvalid ||
       next_operation <= 0) {
     // Initiating a new update, no more state needs to be initialized.
-    TEST_AND_RETURN_FALSE(VerifySourcePartitions());
+    TEST_AND_RETURN_FALSE(VerifySourcePartition());
     return true;
   }
   next_operation_num_ = next_operation;

--- a/src/update_engine/delta_performer.cc
+++ b/src/update_engine/delta_performer.cc
@@ -343,15 +343,6 @@ bool DeltaPerformer::Write(const void* bytes, size_t count,
   }
 
   while (next_operation_num_ < num_total_operations_) {
-    if (fd_ == -1) {
-      if (Open(install_plan_->install_path.c_str(),
-	       O_TRUNC | O_WRONLY | O_CREAT | O_LARGEFILE,
-	       0644) < 0) {
-	LOG(ERROR) << "Unable to open output file " << install_plan_->install_path;
-	return false;
-      }
-    }
-
     const bool is_noop =
         (next_operation_num_ >= num_rootfs_operations_);
     const DeltaArchiveManifest_InstallOperation &op =

--- a/src/update_engine/delta_performer.cc
+++ b/src/update_engine/delta_performer.cc
@@ -941,8 +941,8 @@ bool DeltaPerformer::VerifySourcePartitions() {
                install_plan_->rootfs_hash.size()) == 0;
     if (!valid) {
       LogVerifyError(false,
-                     StringForHashBytes(install_plan_->kernel_hash.data(),
-                                        install_plan_->kernel_hash.size()),
+                     StringForHashBytes(install_plan_->rootfs_hash.data(),
+                                        install_plan_->rootfs_hash.size()),
                      StringForHashBytes(info.hash().data(),
                                         info.hash().size()));
     }

--- a/src/update_engine/delta_performer_unittest.cc
+++ b/src/update_engine/delta_performer_unittest.cc
@@ -430,7 +430,7 @@ static void ApplyDeltaFile(bool full_kernel, bool full_rootfs, bool noop,
 
     if (noop) {
       EXPECT_EQ(1, manifest.install_operations_size());
-      EXPECT_EQ(1, manifest.kernel_install_operations_size());
+      EXPECT_EQ(1, manifest.noop_operations_size());
     }
 
     if (full_kernel) {

--- a/src/update_engine/delta_performer_unittest.cc
+++ b/src/update_engine/delta_performer_unittest.cc
@@ -43,9 +43,6 @@ extern const char* kUnittestPublicKey2Path;
 
 static const size_t kBlockSize = 4096;
 
-static const int kDefaultKernelSize = 4096; // Something small for a test
-static const char* kNewDataString = "This is new data.";
-
 namespace {
 struct DeltaState {
   string a_img;
@@ -54,12 +51,6 @@ struct DeltaState {
 
   string delta_path;
   uint64_t metadata_size;
-
-  string old_kernel;
-  vector<char> old_kernel_data;
-
-  string new_kernel;
-  vector<char> new_kernel_data;
 
   // The in-memory copy of delta file.
   vector<char> delta;
@@ -239,8 +230,7 @@ static void SignGeneratedShellPayload(SignatureTest signature_test,
   }
 }
 
-static void GenerateDeltaFile(bool full_kernel,
-                              bool full_rootfs,
+static void GenerateDeltaFile(bool full_rootfs,
                               bool noop,
                               SignatureTest signature_test,
                               DeltaState *state) {
@@ -317,36 +307,6 @@ static void GenerateDeltaFile(bool full_kernel,
                                  sizeof(kRandomString)));
   }
 
-  string old_kernel;
-  EXPECT_TRUE(utils::MakeTempFile("/tmp/old_kernel.XXXXXX",
-                                  &state->old_kernel,
-                                  NULL));
-
-  string new_kernel;
-  EXPECT_TRUE(utils::MakeTempFile("/tmp/new_kernel.XXXXXX",
-                                  &state->new_kernel,
-                                  NULL));
-
-  state->old_kernel_data.resize(kDefaultKernelSize);
-  state->new_kernel_data.resize(state->old_kernel_data.size());
-  FillWithData(&state->old_kernel_data);
-  FillWithData(&state->new_kernel_data);
-
-  // change the new kernel data
-  strcpy(&state->new_kernel_data[0], kNewDataString);
-
-  if (noop) {
-    state->old_kernel_data = state->new_kernel_data;
-  }
-
-  // Write kernels to disk
-  EXPECT_TRUE(utils::WriteFile(state->old_kernel.c_str(),
-                               &state->old_kernel_data[0],
-                               state->old_kernel_data.size()));
-  EXPECT_TRUE(utils::WriteFile(state->new_kernel.c_str(),
-                               &state->new_kernel_data[0],
-                               state->new_kernel_data.size()));
-
   EXPECT_TRUE(utils::MakeTempFile("/tmp/delta.XXXXXX",
                                   &state->delta_path,
                                   NULL));
@@ -363,8 +323,6 @@ static void GenerateDeltaFile(bool full_kernel,
             full_rootfs ? "" : state->a_img,
             b_mnt,
             state->b_img,
-            full_kernel ? "" : state->old_kernel,
-            state->new_kernel,
             state->delta_path,
             private_key,
             &state->metadata_size));
@@ -383,7 +341,7 @@ static void GenerateDeltaFile(bool full_kernel,
   }
 }
 
-static void ApplyDeltaFile(bool full_kernel, bool full_rootfs, bool noop,
+static void ApplyDeltaFile(bool full_rootfs, bool noop,
                            SignatureTest signature_test, DeltaState* state,
                            bool hash_checks_mandatory,
                            OperationHashTest op_hash_test,
@@ -433,14 +391,6 @@ static void ApplyDeltaFile(bool full_kernel, bool full_rootfs, bool noop,
       EXPECT_EQ(1, manifest.noop_operations_size());
     }
 
-    if (full_kernel) {
-      EXPECT_FALSE(manifest.has_old_kernel_info());
-    } else {
-      EXPECT_EQ(state->old_kernel_data.size(),
-                manifest.old_kernel_info().size());
-      EXPECT_FALSE(manifest.old_kernel_info().hash().empty());
-    }
-
     if (full_rootfs) {
       EXPECT_FALSE(manifest.has_old_rootfs_info());
     } else {
@@ -448,10 +398,8 @@ static void ApplyDeltaFile(bool full_kernel, bool full_rootfs, bool noop,
       EXPECT_FALSE(manifest.old_rootfs_info().hash().empty());
     }
 
-    EXPECT_EQ(state->new_kernel_data.size(), manifest.new_kernel_info().size());
     EXPECT_EQ(state->image_size, manifest.new_rootfs_info().size());
 
-    EXPECT_FALSE(manifest.new_kernel_info().hash().empty());
     EXPECT_FALSE(manifest.new_rootfs_info().hash().empty());
   }
 
@@ -487,11 +435,8 @@ static void ApplyDeltaFile(bool full_kernel, bool full_rootfs, bool noop,
             OmahaHashCalculator::RawHashOfFile(state->a_img,
                                                state->image_size,
                                                &install_plan.rootfs_hash));
-  EXPECT_TRUE(OmahaHashCalculator::RawHashOfData(state->old_kernel_data,
-                                                 &install_plan.kernel_hash));
 
   EXPECT_EQ(0, (*performer)->Open(state->a_img.c_str(), 0, 0));
-  EXPECT_EQ(0, (*performer)->OpenKernel(state->old_kernel.c_str()));
 
   ActionExitCode expected_error, actual_error;
   bool continue_writing;
@@ -574,27 +519,12 @@ void VerifyPayloadResult(DeltaPerformer* performer,
     return;
   }
 
-  CompareFilesByBlock(state->old_kernel, state->new_kernel);
   CompareFilesByBlock(state->a_img, state->b_img);
 
-  vector<char> updated_kernel_partition;
-  EXPECT_TRUE(utils::ReadFile(state->old_kernel, &updated_kernel_partition));
-  EXPECT_EQ(0, strncmp(&updated_kernel_partition[0], kNewDataString,
-                       strlen(kNewDataString)));
-
-  uint64_t new_kernel_size;
-  vector<char> new_kernel_hash;
   uint64_t new_rootfs_size;
   vector<char> new_rootfs_hash;
-  EXPECT_TRUE(performer->GetNewPartitionInfo(&new_kernel_size,
-                                            &new_kernel_hash,
-                                            &new_rootfs_size,
-                                            &new_rootfs_hash));
-  EXPECT_EQ(kDefaultKernelSize, new_kernel_size);
-  vector<char> expected_new_kernel_hash;
-  EXPECT_TRUE(OmahaHashCalculator::RawHashOfData(state->new_kernel_data,
-                                                 &expected_new_kernel_hash));
-  EXPECT_TRUE(expected_new_kernel_hash == new_kernel_hash);
+  EXPECT_TRUE(performer->GetNewPartitionInfo(&new_rootfs_size,
+                                             &new_rootfs_hash));
   EXPECT_EQ(state->image_size, new_rootfs_size);
   vector<char> expected_new_rootfs_hash;
   EXPECT_EQ(state->image_size,
@@ -621,18 +551,16 @@ void VerifyPayload(DeltaPerformer* performer,
   VerifyPayloadResult(performer, state, expected_result);
 }
 
-void DoSmallImageTest(bool full_kernel, bool full_rootfs, bool noop,
+void DoSmallImageTest(bool full_rootfs, bool noop,
                       SignatureTest signature_test,
                       bool hash_checks_mandatory) {
   DeltaState state;
   DeltaPerformer *performer;
-  GenerateDeltaFile(full_kernel, full_rootfs, noop, signature_test, &state);
+  GenerateDeltaFile(full_rootfs, noop, signature_test, &state);
   ScopedPathUnlinker a_img_unlinker(state.a_img);
   ScopedPathUnlinker b_img_unlinker(state.b_img);
   ScopedPathUnlinker delta_unlinker(state.delta_path);
-  ScopedPathUnlinker old_kernel_unlinker(state.old_kernel);
-  ScopedPathUnlinker new_kernel_unlinker(state.new_kernel);
-  ApplyDeltaFile(full_kernel, full_rootfs, noop, signature_test,
+  ApplyDeltaFile(full_rootfs, noop, signature_test,
                  &state, hash_checks_mandatory, kValidOperationData,
                  &performer);
   VerifyPayload(performer, &state, signature_test);
@@ -641,14 +569,12 @@ void DoSmallImageTest(bool full_kernel, bool full_rootfs, bool noop,
 void DoOperationHashMismatchTest(OperationHashTest op_hash_test,
                                  bool hash_checks_mandatory) {
   DeltaState state;
-  GenerateDeltaFile(true, true, false, kSignatureGenerated, &state);
+  GenerateDeltaFile(true, false, kSignatureGenerated, &state);
   ScopedPathUnlinker a_img_unlinker(state.a_img);
   ScopedPathUnlinker b_img_unlinker(state.b_img);
   ScopedPathUnlinker delta_unlinker(state.delta_path);
-  ScopedPathUnlinker old_kernel_unlinker(state.old_kernel);
-  ScopedPathUnlinker new_kernel_unlinker(state.new_kernel);
   DeltaPerformer *performer;
-  ApplyDeltaFile(true, true, false, kSignatureGenerated,
+  ApplyDeltaFile(true, false, kSignatureGenerated,
                  &state, hash_checks_mandatory, op_hash_test, &performer);
 }
 
@@ -678,31 +604,31 @@ TEST(DeltaPerformerTest, ExtentsToByteStringTest) {
 
 TEST(DeltaPerformerTest, RunAsRootSmallImageTest) {
   bool hash_checks_mandatory = false;
-  DoSmallImageTest(false, false, false, kSignatureGenerator,
+  DoSmallImageTest(false, false, kSignatureGenerator,
                    hash_checks_mandatory);
 }
 
 TEST(DeltaPerformerTest, RunAsRootFullSmallImageTest) {
   bool hash_checks_mandatory = true;
-  DoSmallImageTest(true, true, false, kSignatureGenerator,
+  DoSmallImageTest(true, false, kSignatureGenerator,
                    hash_checks_mandatory);
 }
 
 TEST(DeltaPerformerTest, RunAsRootNoopSmallImageTest) {
   bool hash_checks_mandatory = false;
-  DoSmallImageTest(false, false, true, kSignatureGenerator,
+  DoSmallImageTest(false, true, kSignatureGenerator,
                    hash_checks_mandatory);
 }
 
 TEST(DeltaPerformerTest, RunAsRootSmallImageSignNoneTest) {
   bool hash_checks_mandatory = false;
-  DoSmallImageTest(false, false, false, kSignatureNone,
+  DoSmallImageTest(false, false, kSignatureNone,
                    hash_checks_mandatory);
 }
 
 TEST(DeltaPerformerTest, RunAsRootSmallImageSignGeneratedTest) {
   bool hash_checks_mandatory = true;
-  DoSmallImageTest(false, false, false, kSignatureGenerated,
+  DoSmallImageTest(false, false, kSignatureGenerated,
                    hash_checks_mandatory);
 }
 
@@ -712,7 +638,6 @@ TEST(DeltaPerformerTest, BadDeltaMagicTest) {
   MockSystemState mock_system_state;
   DeltaPerformer performer(&prefs, &mock_system_state, &install_plan);
   EXPECT_EQ(0, performer.Open("/dev/null", 0, 0));
-  EXPECT_EQ(0, performer.OpenKernel("/dev/null"));
   EXPECT_TRUE(performer.Write("junk", 4));
   EXPECT_TRUE(performer.Write("morejunk", 8));
   EXPECT_FALSE(performer.Write("morejunk", 8));
@@ -741,7 +666,6 @@ TEST(DeltaPerformerTest, WriteUpdatesPayloadState) {
   MockSystemState mock_system_state;
   DeltaPerformer performer(&prefs, &mock_system_state, &install_plan);
   EXPECT_EQ(0, performer.Open("/dev/null", 0, 0));
-  EXPECT_EQ(0, performer.OpenKernel("/dev/null"));
 
   EXPECT_CALL(*(mock_system_state.mock_payload_state()),
               DownloadProgress(4)).Times(1);

--- a/src/update_engine/download_action.cc
+++ b/src/update_engine/download_action.cc
@@ -117,8 +117,6 @@ void DownloadAction::TransferComplete(HttpFetcher *fetcher, bool successful) {
       LOG(ERROR) << "Download of " << install_plan_.download_url
                  << " failed due to payload verification error.";
     } else if (!delta_performer_->GetNewPartitionInfo(
-        &install_plan_.kernel_size,
-        &install_plan_.kernel_hash,
         &install_plan_.rootfs_size,
         &install_plan_.rootfs_hash)) {
       LOG(ERROR) << "Unable to get new partition hash info.";

--- a/src/update_engine/download_action.cc
+++ b/src/update_engine/download_action.cc
@@ -45,20 +45,20 @@ void DownloadAction::PerformAction() {
 
   if (writer_) {
     LOG(INFO) << "Using writer for test.";
-    int rc = writer_->Open(install_plan_.install_path.c_str(),
-			   O_TRUNC | O_WRONLY | O_CREAT | O_LARGEFILE,
-			   0644);
-    if (rc < 0) {
-      LOG(ERROR) << "Unable to open output file " << install_plan_.install_path;
-      // report error to processor
-      processor_->ActionComplete(this, kActionCodeInstallDeviceOpenError);
-      return;
-    }    
   } else {
     delta_performer_.reset(new DeltaPerformer(prefs_,
                                               system_state_,
                                               &install_plan_));
     writer_ = delta_performer_.get();
+  }
+  int rc = writer_->Open(install_plan_.install_path.c_str(),
+                         O_TRUNC | O_WRONLY | O_CREAT | O_LARGEFILE,
+                         0644);
+  if (rc < 0) {
+    LOG(ERROR) << "Unable to open output file " << install_plan_.install_path;
+    // report error to processor
+    processor_->ActionComplete(this, kActionCodeInstallDeviceOpenError);
+    return;
   }
   if (delegate_) {
     delegate_->SetDownloadStatus(true);  // Set to active.

--- a/src/update_engine/download_action_unittest.cc
+++ b/src/update_engine/download_action_unittest.cc
@@ -134,8 +134,7 @@ void TestWithData(const vector<char>& data,
                            "",
                            size,
                            hash,
-                           output_temp_file.GetPath(),
-                           "");
+                           output_temp_file.GetPath());
   ObjectFeederAction<InstallPlan> feeder_action;
   feeder_action.set_obj(install_plan);
   PrefsMock prefs;
@@ -248,7 +247,7 @@ void TestTerminateEarly(bool use_download_delegate) {
 
     // takes ownership of passed in HttpFetcher
     ObjectFeederAction<InstallPlan> feeder_action;
-    InstallPlan install_plan(false, "", 0, "", temp_file.GetPath(), "");
+    InstallPlan install_plan(false, "", 0, "", temp_file.GetPath());
     feeder_action.set_obj(install_plan);
     PrefsMock prefs;
     DownloadAction download_action(&prefs, NULL,
@@ -350,7 +349,6 @@ TEST(DownloadActionTest, PassObjectOutTest) {
                            "",
                            1,
                            OmahaHashCalculator::OmahaHashOfString("x"),
-                           "/dev/null",
                            "/dev/null");
   ObjectFeederAction<InstallPlan> feeder_action;
   feeder_action.set_obj(install_plan);
@@ -386,7 +384,7 @@ TEST(DownloadActionTest, BadOutFileTest) {
   DirectFileWriter writer;
 
   // takes ownership of passed in HttpFetcher
-  InstallPlan install_plan(false, "", 0, "", path, "");
+  InstallPlan install_plan(false, "", 0, "", path);
   ObjectFeederAction<InstallPlan> feeder_action;
   feeder_action.set_obj(install_plan);
   PrefsMock prefs;

--- a/src/update_engine/filesystem_copier_action.h
+++ b/src/update_engine/filesystem_copier_action.h
@@ -37,7 +37,7 @@ class ActionTraits<FilesystemCopierAction> {
 
 class FilesystemCopierAction : public Action<FilesystemCopierAction> {
  public:
-  FilesystemCopierAction(bool copying_kernel_install_path, bool verify_hash);
+  FilesystemCopierAction(bool verify_hash);
 
   typedef ActionTraits<FilesystemCopierAction>::InputObjectType
   InputObjectType;
@@ -97,10 +97,6 @@ class FilesystemCopierAction : public Action<FilesystemCopierAction> {
   // whole partition. Currently this supports only the root file system assuming
   // it's ext3-compatible.
   void DetermineFilesystemSize(int fd);
-
-  // If true, this action is copying to the kernel_install_path from
-  // the install plan, otherwise it's copying just to the install_path.
-  const bool copying_kernel_install_path_;
 
   // If true, this action is running in applied update hash verification mode --
   // it computes a hash for the target install path and compares it against the

--- a/src/update_engine/full_update_generator.h
+++ b/src/update_engine/full_update_generator.h
@@ -13,22 +13,19 @@ namespace chromeos_update_engine {
 
 class FullUpdateGenerator {
  public:
-  // Given a new rootfs and kernel (|new_image|, |new_kernel_part|), reads them
-  // sequentially, creating a full update of chunk_size chunks. Populates
-  // |graph|, |kernel_ops|, and |final_order|, with data about the update
+  // Reads a new rootfs (|new_image|), creating a full update of chunk_size
+  // chunks. Populates |graph| and |final_order| with data about the update
   // operations, and writes relevant data to |fd|, updating |data_file_size| as
   // it does. Only the first |image_size| bytes are read from |new_image|
   // assuming that this is the actual file system.
   static bool Run(
       Graph* graph,
-      const std::string& new_kernel_part,
       const std::string& new_image,
       off_t image_size,
       int fd,
       off_t* data_file_size,
       off_t chunk_size,
       off_t block_size,
-      std::vector<DeltaArchiveManifest_InstallOperation>* kernel_ops,
       std::vector<Vertex::Index>* final_order);
 
  private:

--- a/src/update_engine/full_update_generator_unittest.cc
+++ b/src/update_engine/full_update_generator_unittest.cc
@@ -25,10 +25,8 @@ class FullUpdateGeneratorTest : public ::testing::Test { };
 
 TEST(FullUpdateGeneratorTest, RunTest) {
   vector<char> new_root(20 * 1024 * 1024);
-  vector<char> new_kern(16 * 1024 * 1024);
   const off_t kChunkSize = 128 * 1024;
   FillWithData(&new_root);
-  FillWithData(&new_kern);
   // Assume hashes take 2 MiB beyond the rootfs.
   off_t new_rootfs_size = new_root.size() - 2 * 1024 * 1024;
 
@@ -38,13 +36,6 @@ TEST(FullUpdateGeneratorTest, RunTest) {
                                   NULL));
   ScopedPathUnlinker new_root_path_unlinker(new_root_path);
   EXPECT_TRUE(WriteFileVector(new_root_path, new_root));
-
-  string new_kern_path;
-  EXPECT_TRUE(utils::MakeTempFile("/tmp/NewFullUpdateTest_K.XXXXXX",
-                                  &new_kern_path,
-                                  NULL));
-  ScopedPathUnlinker new_kern_path_unlinker(new_kern_path);
-  EXPECT_TRUE(WriteFileVector(new_kern_path, new_kern));
 
   string out_blobs_path;
   int out_blobs_fd;
@@ -57,22 +48,18 @@ TEST(FullUpdateGeneratorTest, RunTest) {
   off_t out_blobs_length = 0;
 
   Graph graph;
-  vector<DeltaArchiveManifest_InstallOperation> kernel_ops;
   vector<Vertex::Index> final_order;
 
   EXPECT_TRUE(FullUpdateGenerator::Run(&graph,
-                                       new_kern_path,
                                        new_root_path,
                                        new_rootfs_size,
                                        out_blobs_fd,
                                        &out_blobs_length,
                                        kChunkSize,
                                        kBlockSize,
-                                       &kernel_ops,
                                        &final_order));
   EXPECT_EQ(new_rootfs_size / kChunkSize, graph.size());
   EXPECT_EQ(new_rootfs_size / kChunkSize, final_order.size());
-  EXPECT_EQ(new_kern.size() / kChunkSize, kernel_ops.size());
   for (off_t i = 0; i < (new_rootfs_size / kChunkSize); ++i) {
     EXPECT_EQ(i, final_order[i]);
     EXPECT_EQ(1, graph[i].op.dst_extents_size());

--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -35,8 +35,6 @@ DEFINE_string(new_dir, "",
               "Directory where the new rootfs is loop mounted read-only");
 DEFINE_string(old_image, "", "Path to the old rootfs");
 DEFINE_string(new_image, "", "Path to the new rootfs");
-DEFINE_string(old_kernel, "", "Path to the old kernel partition image");
-DEFINE_string(new_kernel, "", "Path to the new kernel partition image");
 DEFINE_string(in_file, "",
               "Path to input delta payload file used to hash/sign payloads "
               "and apply delta over old_image (for debugging)");
@@ -183,19 +181,12 @@ void ApplyDelta() {
   // Get original checksums
   LOG(INFO) << "Calculating original checksums";
   PartitionInfo kern_info, root_info;
-  CHECK(DeltaDiffGenerator::InitializePartitionInfo(true,  // is_kernel
-                                                    FLAGS_old_kernel,
-                                                    &kern_info));
-  CHECK(DeltaDiffGenerator::InitializePartitionInfo(false,  // is_kernel
-                                                    FLAGS_old_image,
+  CHECK(DeltaDiffGenerator::InitializePartitionInfo(FLAGS_old_image,
                                                     &root_info));
-  install_plan.kernel_hash.assign(kern_info.hash().begin(),
-                                  kern_info.hash().end());
   install_plan.rootfs_hash.assign(root_info.hash().begin(),
                                   root_info.hash().end());
   DeltaPerformer performer(&prefs, NULL, &install_plan);
   CHECK_EQ(performer.Open(FLAGS_old_image.c_str(), 0, 0), 0);
-  CHECK_EQ(performer.OpenKernel(FLAGS_old_kernel.c_str()), 0);
   vector<char> buf(1024 * 1024);
   int fd = open(FLAGS_in_file.c_str(), O_RDONLY, 0);
   CHECK_GE(fd, 0);
@@ -266,8 +257,6 @@ int Main(int argc, char** argv) {
                                                    FLAGS_old_image,
                                                    FLAGS_new_dir,
                                                    FLAGS_new_image,
-                                                   FLAGS_old_kernel,
-                                                   FLAGS_new_kernel,
                                                    FLAGS_out_file,
                                                    FLAGS_private_key,
                                                    &metadata_size)) {

--- a/src/update_engine/install_plan.cc
+++ b/src/update_engine/install_plan.cc
@@ -16,21 +16,17 @@ InstallPlan::InstallPlan(bool is_resume,
                          const string& url,
                          uint64_t payload_size,
                          const string& payload_hash,
-                         const string& install_path,
-                         const string& kernel_install_path)
+                         const string& install_path)
     : is_resume(is_resume),
       download_url(url),
       payload_size(payload_size),
       payload_hash(payload_hash),
       install_path(install_path),
-      kernel_install_path(kernel_install_path),
-      kernel_size(0),
       rootfs_size(0),
       hash_checks_mandatory(false) {}
 
 InstallPlan::InstallPlan() : is_resume(false),
                              payload_size(0),
-                             kernel_size(0),
                              rootfs_size(0),
                              hash_checks_mandatory(false) {}
 
@@ -40,8 +36,7 @@ bool InstallPlan::operator==(const InstallPlan& that) const {
           (download_url == that.download_url) &&
           (payload_size == that.payload_size) &&
           (payload_hash == that.payload_hash) &&
-          (install_path == that.install_path) &&
-          (kernel_install_path == that.kernel_install_path));
+          (install_path == that.install_path));
 }
 
 bool InstallPlan::operator!=(const InstallPlan& that) const {
@@ -55,7 +50,6 @@ void InstallPlan::Dump() const {
             << ", payload size: " << payload_size
             << ", payload hash: " << payload_hash
             << ", install_path: " << install_path
-            << ", kernel_install_path: " << kernel_install_path
             << ", hash_checks_mandatory: " << utils::ToString(
                 hash_checks_mandatory);
 }

--- a/src/update_engine/install_plan.h
+++ b/src/update_engine/install_plan.h
@@ -19,8 +19,7 @@ struct InstallPlan {
               const std::string& url,
               uint64_t payload_size,
               const std::string& payload_hash,
-              const std::string& install_path,
-              const std::string& kernel_install_path);
+              const std::string& install_path);
 
   // Default constructor: Initialize all members which don't have a class
   // initializer.
@@ -37,9 +36,8 @@ struct InstallPlan {
   uint64_t payload_size;                 // size of the payload
   std::string payload_hash ;             // SHA256 hash of the payload
   std::string install_path;              // path to install device
-  std::string kernel_install_path;       // path to kernel install device
 
-  // The fields below are used for kernel and rootfs verification. The flow is:
+  // The fields below are used for rootfs verification. The flow is:
   //
   // 1. FilesystemCopierAction(verify_hash=false) computes and fills in the
   // source partition sizes and hashes.
@@ -50,9 +48,7 @@ struct InstallPlan {
   //
   // 4. FilesystemCopierAction(verify_hashes=true) computes and verifies the
   // applied partition sizes and hashes against the expected values.
-  uint64_t kernel_size;
   uint64_t rootfs_size;
-  std::vector<char> kernel_hash;
   std::vector<char> rootfs_hash;
 
   // True if payload hash checks are mandatory based on the system state and

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -62,8 +62,6 @@ void OmahaResponseHandlerAction::PerformAction() {
   TEST_AND_RETURN(GetInstallDev(
       (!boot_device_.empty() ? boot_device_ : utils::BootDevice()),
       &install_plan_.install_path));
-  install_plan_.kernel_install_path =
-      utils::BootKernelName(install_plan_.install_path);
 
   TEST_AND_RETURN(HasOutputPipe());
   if (HasOutputPipe())

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -177,9 +177,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   shared_ptr<OmahaResponseHandlerAction> response_handler_action(
       new OmahaResponseHandlerAction(system_state_));
   shared_ptr<FilesystemCopierAction> filesystem_copier_action(
-      new FilesystemCopierAction(false, false));
-  shared_ptr<FilesystemCopierAction> kernel_filesystem_copier_action(
-      new FilesystemCopierAction(true, false));
+      new FilesystemCopierAction(false));
   shared_ptr<OmahaRequestAction> download_started_action(
       new OmahaRequestAction(system_state_,
                              new OmahaEvent(
@@ -200,9 +198,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
                              new LibcurlHttpFetcher(),
                              false));
   shared_ptr<FilesystemCopierAction> filesystem_verifier_action(
-      new FilesystemCopierAction(false, true));
-  shared_ptr<FilesystemCopierAction> kernel_filesystem_verifier_action(
-      new FilesystemCopierAction(true, true));
+      new FilesystemCopierAction(true));
   shared_ptr<PostinstallRunnerAction> postinstall_runner_action(
       new PostinstallRunnerAction(omaha_request_params_->app_id()));
   shared_ptr<OmahaRequestAction> update_complete_action(
@@ -218,14 +214,10 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   actions_.push_back(shared_ptr<AbstractAction>(update_check_action));
   actions_.push_back(shared_ptr<AbstractAction>(response_handler_action));
   actions_.push_back(shared_ptr<AbstractAction>(filesystem_copier_action));
-  actions_.push_back(shared_ptr<AbstractAction>(
-      kernel_filesystem_copier_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_started_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_finished_action));
   actions_.push_back(shared_ptr<AbstractAction>(filesystem_verifier_action));
-  actions_.push_back(shared_ptr<AbstractAction>(
-      kernel_filesystem_verifier_action));
   actions_.push_back(shared_ptr<AbstractAction>(postinstall_runner_action));
   actions_.push_back(shared_ptr<AbstractAction>(update_complete_action));
 
@@ -241,14 +233,10 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   BondActions(response_handler_action.get(),
               filesystem_copier_action.get());
   BondActions(filesystem_copier_action.get(),
-              kernel_filesystem_copier_action.get());
-  BondActions(kernel_filesystem_copier_action.get(),
               download_action.get());
   BondActions(download_action.get(),
               filesystem_verifier_action.get());
   BondActions(filesystem_verifier_action.get(),
-              kernel_filesystem_verifier_action.get());
-  BondActions(kernel_filesystem_verifier_action.get(),
               postinstall_runner_action.get());
 }
 

--- a/src/update_engine/update_attempter_unittest.cc
+++ b/src/update_engine/update_attempter_unittest.cc
@@ -149,7 +149,7 @@ TEST_F(UpdateAttempterTest, GetErrorCodeForActionTest) {
   EXPECT_EQ(kActionCodeOmahaResponseHandlerError,
             GetErrorCodeForAction(&omaha_response_handler_action,
                                   kActionCodeError));
-  FilesystemCopierAction filesystem_copier_action(false, false);
+  FilesystemCopierAction filesystem_copier_action(false);
   EXPECT_EQ(kActionCodeFilesystemCopierError,
             GetErrorCodeForAction(&filesystem_copier_action, kActionCodeError));
   PostinstallRunnerAction postinstall_runner_action(OmahaRequestParams::kAppId);

--- a/src/update_engine/update_metadata.proto
+++ b/src/update_engine/update_metadata.proto
@@ -162,9 +162,9 @@ message DeltaArchiveManifest {
   optional uint64 signatures_offset = 4;
   optional uint64 signatures_size = 5;
 
+  // Deprecated IDs 6 and 7, do not reuse.
+
   // Partition data that can be used to validate the update.
-  optional PartitionInfo old_kernel_info = 6;
-  optional PartitionInfo new_kernel_info = 7;
   optional PartitionInfo old_rootfs_info = 8;
   optional PartitionInfo new_rootfs_info = 9;
 }

--- a/src/update_engine/update_metadata.proto
+++ b/src/update_engine/update_metadata.proto
@@ -126,7 +126,30 @@ message DeltaArchiveManifest {
     optional bytes data_sha256_hash = 8;
   }
   repeated InstallOperation install_operations = 1;
-  repeated InstallOperation kernel_install_operations = 2;
+
+  // This field is maintained for compatibility with older update_engine
+  // clients. In the ChromeOS days it covered the kernel partition but in
+  // CoreOS it has only been used to insert a dummy operation to account for
+  // the signatures tacked onto the end of the payload. The code was not smart
+  // enough to stop passing data to the filesystem writer code after the
+  // signatures_offset had been reached, instead using the magic punch-hole
+  // value to skip over the extra data. Since CoreOS versions of update_engine
+  // only partially removed support kernel partitions passing anything other
+  // than dummy operations will trigger broken code paths but omitting the
+  // dummy operations will fail when the filesystem writer receives unexpected
+  // data. Therefore to work with old versions it strictly *must* look like:
+  //
+  //   noop_operations: {
+  //     type: REPLACE
+  //     data_offset: signatures_offset
+  //     data_length: signatures_size
+  //     dst_extents: {
+  //       start_block: UINT64_MAX
+  //       num_blocks: (signature_size + block_size - 1) / block_size
+  //     }
+  //   }
+  //
+  repeated InstallOperation noop_operations = 2;
 
   // (At time of writing) usually 4096
   optional uint32 block_size = 3 [default = 4096];


### PR DESCRIPTION
Resurrection the old kernel partition code to update kernel files has proven tricky. Instead just pull out the old code and write something new that works better for files. The new kernel update code will come in a following PR.