### PR TITLE
build: detect which namespace gflags uses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,38 @@ AC_CHECK_LIB([bz2], [BZ2_bzDecompressInit], [],
 AC_CHECK_HEADERS([bzlib.h], [],
                  [AC_MSG_ERROR([*** bzlib.h not found])])
 
+# Detect libgflags presence and namespace. (may be gflags or google)
+# autoconf's C++ mode is only enabled for this test because other
+# macros like AM_PATH_GLIB_2_0 assume the default C mode.
+LIBS="$LIBS -lgflags"
+AC_LANG_PUSH([C++])
+AC_CHECK_HEADERS([gflags/gflags.h], [],
+                 [AC_MSG_ERROR([*** gflags/gflags.h not found])])
+AC_CACHE_CHECK(
+ [gflags namespace],
+ [ac_cv_gflags_namespace],
+ [ac_cv_gflags_namespace="no"
+  # gflags prior to 2.1.2 does not define GFLAGS_NAMESPACE
+  AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <gflags/gflags.h>
+                     #ifndef GFLAGS_NAMESPACE
+                     #error GFLAGS_NAMESPACE
+                     #endif]])],
+                    [try_gflags_namespaces=GFLAGS_NAMESPACE],
+                    [try_gflags_namespaces="gflags google"])
+  for try_gflags_ns in $try_gflags_namespaces
+  do
+    AC_LINK_IFELSE([AC_LANG_SOURCE([[#include <gflags/gflags.h>
+      int main(int argc, char** argv) {
+        return ${try_gflags_ns}::ParseCommandLineFlags(&argc, &argv, true);
+      }]])],
+      [ac_cv_gflags_namespace="$try_gflags_ns"; break])
+  done])
+AC_LANG_POP([C++])
+AS_IF([test "x${ac_cv_gflags_namespace}" = "xno"],
+      [AC_MSG_ERROR([*** gflags not found])])
+AS_IF([test "x${ac_cv_gflags_namespace}" != "xGFLAGS_NAMESPACE"],
+      [AC_DEFINE_UNQUOTED([GFLAGS_NAMESPACE], [$ac_cv_gflags_namespace])])
+
 AM_PATH_GLIB_2_0([2.36.0], [],
                  [AC_MSG_ERROR([*** glib >= 2.36 not found])],
                  gthread gio gio-unix)
@@ -44,7 +76,6 @@ PKG_CHECK_MODULES([DEPS],
                    libchrome-180609
                    libcrypto
                    libcurl
-                   libgflags
                    libssl
                    libxml-2.0
                    protobuf])

--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -203,7 +203,7 @@ void ApplyDelta() {
 }
 
 int Main(int argc, char** argv) {
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
   CommandLine::Init(argc, argv);
   Terminator::Init();
   Subprocess::Init();

--- a/src/update_engine/main.cc
+++ b/src/update_engine/main.cc
@@ -144,7 +144,7 @@ int main(int argc, char** argv) {
   dbus_threads_init_default();
   chromeos_update_engine::Terminator::Init();
   chromeos_update_engine::Subprocess::Init();
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
   CommandLine::Init(argc, argv);
   chromeos_update_engine::SetupLogging();
   if (!FLAGS_foreground)

--- a/src/update_engine/update_engine_client.cc
+++ b/src/update_engine/update_engine_client.cc
@@ -212,7 +212,7 @@ int main(int argc, char** argv) {
   // Boilerplate init commands.
   dbus_threads_init_default();
   chromeos_update_engine::Subprocess::Init();
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
   // Update the status if requested.
   if (FLAGS_reset_status) {


### PR DESCRIPTION
gflags 2.0 and earlier used the `google` namespace while versions 2.1
and 2.1.1 switch to the `gflags` namespace, breaking both API and ABI
compatibility. Then 2.1.2 restores 2.0 ABI compatibility and provides a
`GFLAGS_NAMESPACE` macro.  Considering a year passed between 2.1.1 and
2.1.2 and the latter still isn't marked stable on Gentoo we define the
macro if it isn't provided.

Use of pkg-config has been removed because 2.1 and later dropped
libgflags.pc in the process of moving to cmake. :(

(note: we will be sticking with gflags 2.0 for now but this has been kicking around in my local tree so long I may as well just commit it)