### PR TITLE
Port fix for intermittant test failures from ChromiumOS

### DIFF
--- a/src/update_engine/extent_ranges.h
+++ b/src/update_engine/extent_ranges.h
@@ -15,9 +15,12 @@
 #include "update_engine/graph_types.h"
 #include "update_engine/update_metadata.pb.h"
 
-// An ExtentRanges object represents an unordered collection of extents
-// (and therefore blocks). Such an object may be modified by adding or
-// subtracting blocks (think: set addition or set subtraction).
+// An ExtentRanges object represents an unordered collection of extents (and
+// therefore blocks). Such an object may be modified by adding or subtracting
+// blocks (think: set addition or set subtraction). Note that ExtentRanges
+// ignores sparse hole extents mostly to avoid confusion between extending a
+// sparse hole range vs. set addition but also to ensure that the delta
+// generator doesn't use sparse holes as scratch space.
 
 namespace chromeos_update_engine {
 
@@ -52,7 +55,7 @@ class ExtentRanges {
 
   // Dumps contents to the log file. Useful for debugging.
   void Dump() const;
-  
+
   uint64_t blocks() const { return blocks_; }
   const ExtentSet& extent_set() const { return extent_set_; }
 

--- a/src/update_engine/extent_ranges_unittest.cc
+++ b/src/update_engine/extent_ranges_unittest.cc
@@ -17,7 +17,7 @@ class ExtentRangesTest : public ::testing::Test {};
 
 namespace {
 void ExpectRangeEq(const ExtentRanges& ranges,
-                   uint64_t* expected,
+                   const uint64_t* expected,
                    size_t sz,
                    int line) {
   uint64_t blocks = 0;
@@ -113,39 +113,50 @@ TEST(ExtentRangesTest, ExtentsOverlapTest) {
   ExpectFalseRangesOverlapOrTouch(10, 20, 35, 10);
   ExpectFalseRangesOverlap(10, 20, 30, 10);
   ExpectRangesOverlap(12, 4, 12, 3);
+
+  ExpectRangesOverlapOrTouch(kSparseHole, 2, kSparseHole, 3);
+  ExpectRangesOverlap(kSparseHole, 2, kSparseHole, 3);
+  ExpectFalseRangesOverlapOrTouch(kSparseHole, 2, 10, 3);
+  ExpectFalseRangesOverlapOrTouch(10, 2, kSparseHole, 3);
+  ExpectFalseRangesOverlap(kSparseHole, 2, 10, 3);
+  ExpectFalseRangesOverlap(10, 2, kSparseHole, 3);
 }
 
 TEST(ExtentRangesTest, SimpleTest) {
   ExtentRanges ranges;
   {
-    uint64_t expected[] = {};
+    static const uint64_t expected[] = {};
     // Can't use arraysize() on 0-length arrays:
     ExpectRangeEq(ranges, expected, 0, __LINE__);
   }
   ranges.SubtractBlock(2);
   {
-    uint64_t expected[] = {};
+    static const uint64_t expected[] = {};
     // Can't use arraysize() on 0-length arrays:
     ExpectRangeEq(ranges, expected, 0, __LINE__);
   }
-  
+
   ranges.AddBlock(0);
   ranges.Dump();
   ranges.AddBlock(1);
   ranges.AddBlock(3);
-  
+
   {
-    uint64_t expected[] = {0, 2, 3, 1};
+    static const uint64_t expected[] = {0, 2, 3, 1};
     EXPECT_RANGE_EQ(ranges, expected);
   }
   ranges.AddBlock(2);
   {
-    uint64_t expected[] = {0, 4};
+    static const uint64_t expected[] = {0, 4};
+    EXPECT_RANGE_EQ(ranges, expected);
+    ranges.AddBlock(kSparseHole);
+    EXPECT_RANGE_EQ(ranges, expected);
+    ranges.SubtractBlock(kSparseHole);
     EXPECT_RANGE_EQ(ranges, expected);
   }
   ranges.SubtractBlock(2);
   {
-    uint64_t expected[] = {0, 2, 3, 1};
+    static const uint64_t expected[] = {0, 2, 3, 1};
     EXPECT_RANGE_EQ(ranges, expected);
   }
 
@@ -153,27 +164,35 @@ TEST(ExtentRangesTest, SimpleTest) {
     ranges.AddExtent(ExtentForRange(i, 50));
   }
   {
-    uint64_t expected[] = {0, 2, 3, 1, 100, 50, 200, 50, 300, 50, 400, 50,
-                           500, 50, 600, 50, 700, 50, 800, 50, 900, 50};
+    static const uint64_t expected[] = {
+      0, 2, 3, 1, 100, 50, 200, 50, 300, 50, 400, 50,
+      500, 50, 600, 50, 700, 50, 800, 50, 900, 50
+    };
     EXPECT_RANGE_EQ(ranges, expected);
   }
 
   ranges.SubtractExtent(ExtentForRange(210, 410 - 210));
   {
-    uint64_t expected[] = {0, 2, 3, 1, 100, 50, 200, 10, 410, 40, 500, 50,
-                           600, 50, 700, 50, 800, 50, 900, 50};
+    static const uint64_t expected[] = {
+      0, 2, 3, 1, 100, 50, 200, 10, 410, 40, 500, 50,
+      600, 50, 700, 50, 800, 50, 900, 50
+    };
     EXPECT_RANGE_EQ(ranges, expected);
   }
   ranges.AddExtent(ExtentForRange(100000, 0));
   {
-    uint64_t expected[] = {0, 2, 3, 1, 100, 50, 200, 10, 410, 40, 500, 50,
-                           600, 50, 700, 50, 800, 50, 900, 50};
+    static const uint64_t expected[] = {
+      0, 2, 3, 1, 100, 50, 200, 10, 410, 40, 500, 50,
+      600, 50, 700, 50, 800, 50, 900, 50
+    };
     EXPECT_RANGE_EQ(ranges, expected);
   }
   ranges.SubtractExtent(ExtentForRange(3, 0));
   {
-    uint64_t expected[] = {0, 2, 3, 1, 100, 50, 200, 10, 410, 40, 500, 50,
-                           600, 50, 700, 50, 800, 50, 900, 50};
+    static const uint64_t expected[] = {
+      0, 2, 3, 1, 100, 50, 200, 10, 410, 40, 500, 50,
+      600, 50, 700, 50, 800, 50, 900, 50
+    };
     EXPECT_RANGE_EQ(ranges, expected);
   }
 }

--- a/src/update_engine/graph_utils.cc
+++ b/src/update_engine/graph_utils.cc
@@ -33,21 +33,17 @@ uint64_t EdgeWeight(const Graph& graph, const Edge& edge) {
 }
 
 void AppendBlockToExtents(vector<Extent>* extents, uint64_t block) {
+  // First try to extend the last extent in |extents|, if any.
   if (!extents->empty()) {
     Extent& extent = extents->back();
-    if (block == kSparseHole) {
-      if (extent.start_block() == kSparseHole) {
-        // Extend sparse hole extent
-        extent.set_num_blocks(extent.num_blocks() + 1);
-        return;
-      } else {
-        // Create new extent below outer 'if'
-      }
-    } else if (extent.start_block() + extent.num_blocks() == block) {
+    uint64_t next_block = extent.start_block() == kSparseHole ?
+        kSparseHole : extent.start_block() + extent.num_blocks();
+    if (next_block == block) {
       extent.set_num_blocks(extent.num_blocks() + 1);
       return;
     }
   }
+  // If unable to extend the last extent, append a new single-block extent.
   Extent new_extent;
   new_extent.set_start_block(block);
   new_extent.set_num_blocks(1);

--- a/src/update_engine/graph_utils_unittest.cc
+++ b/src/update_engine/graph_utils_unittest.cc
@@ -19,7 +19,7 @@ class GraphUtilsTest : public ::testing::Test {};
 
 TEST(GraphUtilsTest, SimpleTest) {
   Graph graph(2);
-  
+
   graph[0].out_edges.insert(make_pair(1, EdgeProperties()));
 
   vector<Extent>& extents = graph[0].out_edges[1].extents;
@@ -31,14 +31,34 @@ TEST(GraphUtilsTest, SimpleTest) {
   graph_utils::AppendBlockToExtents(&extents, 2);
   EXPECT_EQ(1, extents.size());
   graph_utils::AppendBlockToExtents(&extents, 4);
-  
+
   EXPECT_EQ(2, extents.size());
   EXPECT_EQ(0, extents[0].start_block());
   EXPECT_EQ(3, extents[0].num_blocks());
   EXPECT_EQ(4, extents[1].start_block());
   EXPECT_EQ(1, extents[1].num_blocks());
-  
+
   EXPECT_EQ(4, graph_utils::EdgeWeight(graph, make_pair(0, 1)));
+}
+
+TEST(GraphUtilsTest, AppendSparseToExtentsTest) {
+  vector<Extent> extents;
+
+  EXPECT_EQ(0, extents.size());
+  graph_utils::AppendBlockToExtents(&extents, kSparseHole);
+  EXPECT_EQ(1, extents.size());
+  graph_utils::AppendBlockToExtents(&extents, 0);
+  EXPECT_EQ(2, extents.size());
+  graph_utils::AppendBlockToExtents(&extents, kSparseHole);
+  graph_utils::AppendBlockToExtents(&extents, kSparseHole);
+
+  ASSERT_EQ(3, extents.size());
+  EXPECT_EQ(kSparseHole, extents[0].start_block());
+  EXPECT_EQ(1, extents[0].num_blocks());
+  EXPECT_EQ(0, extents[1].start_block());
+  EXPECT_EQ(1, extents[1].num_blocks());
+  EXPECT_EQ(kSparseHole, extents[2].start_block());
+  EXPECT_EQ(2, extents[2].num_blocks());
 }
 
 TEST(GraphUtilsTest, BlocksInExtentsTest) {
@@ -66,7 +86,7 @@ TEST(GraphUtilsTest, BlocksInExtentsTest) {
 
 TEST(GraphUtilsTest, DepsTest) {
   Graph graph(3);
-  
+
   graph_utils::AddReadBeforeDep(&graph[0], 1, 3);
   EXPECT_EQ(1, graph[0].out_edges.size());
   {
@@ -93,7 +113,7 @@ TEST(GraphUtilsTest, DepsTest) {
   graph[2].out_edges[1].write_extents.swap(graph[2].out_edges[1].extents);
   graph_utils::DropWriteBeforeDeps(&graph[2].out_edges);
   EXPECT_EQ(0, graph[2].out_edges.size());
-  
+
   EXPECT_EQ(1, graph[0].out_edges.size());
   graph_utils::DropIncomingEdgesTo(&graph, 1);
   EXPECT_EQ(0, graph[0].out_edges.size());


### PR DESCRIPTION
The test `PayloadProcessorTest.RunAsRootSmallImageSignGeneratedTest` intermittently fails, this appears to be the fix, from 2013... It does not impact current systems since it only causes issues with delta updates.

AU: Don't use sparse holes as scratch space in the delta generator.

This patch fixes a number of bugs related to handling of sparse holes
in the context of scratch space in the delta diff generator and adds
appropriate unit tests. Most notably:

- Ignore sparse holes for the purposes of ExtentRanges. This prevents
  the generator from using sparse holes as scratch.

- Adds two unit tests to catch using sparse holes as scratch in a more
  deterministric way.

- Handle correctly sparse holes in
  GraphUtils::AppendBlockToExtents. For example, previously, if one
  adds block 0 to a single-block kSparseHole extent, the extent would
  have been simply extended.

BUG=chromium:238440
TEST=unit tests, trybots

Change-Id: I3fedcc93af319ee741821ad9d1a2a57b7a7d5de2
Reviewed-on: https://gerrit.chromium.org/gerrit/50448
Commit-Queue: Darin Petkov <petkov@chromium.org>
Reviewed-by: Darin Petkov <petkov@chromium.org>
Tested-by: Darin Petkov <petkov@chromium.org>