### PR TITLE
Prep work for kernel updates

### DIFF
--- a/src/update_engine/action_processor.h
+++ b/src/update_engine/action_processor.h
@@ -66,6 +66,11 @@ enum ActionExitCode {
   kActionCodeOmahaUpdateDeferredForBackoff = 40,
   kActionCodePostinstallPowerwashError = 41,
 
+  // DownloadIncomplete isn't an error to report, it is analogous to EAGAIN
+  // and for internal use to indicate that the processing must pause until
+  // more data has been received.
+  kActionCodeDownloadIncomplete = 100,
+
   // Note: When adding new error codes, please remember to add the
   // error into one of the buckets in PayloadState::UpdateFailed method so
   // that the retries across URLs and the payload backoff mechanism work

--- a/src/update_engine/delta_metadata.cc
+++ b/src/update_engine/delta_metadata.cc
@@ -14,23 +14,20 @@ namespace chromeos_update_engine {
 const char kDeltaMagic[] = "CrAU";
 static_assert(kDeltaMagicSize == sizeof(kDeltaMagic) - 1, "invalid size");
 
-DeltaMetadata::ParseResult DeltaMetadata::ParsePayload(
+ActionExitCode DeltaMetadata::ParsePayload(
     const std::vector<char>& payload,
     DeltaArchiveManifest* manifest,
-    uint64_t* metadata_size,
-    ActionExitCode* error) {
-  *error = kActionCodeSuccess;
+    uint64_t* metadata_size) {
 
   if (payload.size() < kDeltaManifestOffset) {
     // Don't have enough bytes to even know the manifest size.
-    return kParseInsufficientData;
+    return kActionCodeDownloadIncomplete;
   }
 
   // Validate the magic string.
   if (memcmp(payload.data(), kDeltaMagic, strlen(kDeltaMagic)) != 0) {
     LOG(ERROR) << "Bad payload format -- invalid delta magic.";
-    *error = kActionCodeDownloadInvalidMetadataMagicString;
-    return kParseError;
+    return kActionCodeDownloadInvalidMetadataMagicString;
   }
 
   // TODO(jaysri): Compare the version number and skip unknown manifest
@@ -48,17 +45,16 @@ DeltaMetadata::ParseResult DeltaMetadata::ParsePayload(
   // We should wait for the full metadata to be read in before we can parse it.
   *metadata_size = kDeltaManifestOffset + manifest_size;
   if (payload.size() < *metadata_size) {
-    return kParseInsufficientData;
+    return kActionCodeDownloadIncomplete;
   }
 
   // The metadata in |payload| is deemed valid. So, it's now safe to
   // parse the protobuf.
   if (!manifest->ParseFromArray(&payload[kDeltaManifestOffset], manifest_size)) {
     LOG(ERROR) << "Unable to parse manifest in update file.";
-    *error = kActionCodeDownloadManifestParseError;
-    return kParseError;
+    return kActionCodeDownloadManifestParseError;
   }
-  return kParseSuccess;
+  return kActionCodeSuccess;
 }
 
 };  // namespace chromeos_update_engine

--- a/src/update_engine/delta_metadata.h
+++ b/src/update_engine/delta_metadata.h
@@ -29,23 +29,16 @@ const uint64_t kDeltaManifestOffset = kDeltaManifestSizeOffset + kDeltaManifestS
 
 class DeltaMetadata {
  public:
-  enum ParseResult {
-    kParseSuccess,
-    kParseError,
-    kParseInsufficientData,
-  };
-
   // Attempts to parse the update metadata starting from the beginning of
   // |payload| into |manifest|. On success, sets |metadata_size| to the total
   // metadata bytes (including the delta magic and metadata size fields), and
-  // returns kParseSuccess. Returns kParseInsufficientData if more data is
-  // needed to parse the complete metadata. Returns kParseError if the metadata
-  // can't be parsed given the payload.
-  static ParseResult ParsePayload(
+  // returns kActionCodeSuccess. Returns kActionCodeDownloadIncomplete if more
+  // data is needed to parse the complete metadata. Returns
+  // kActionCodeDownloadManifestParseError if the metadata can't be parsed.
+  static ActionExitCode ParsePayload(
       const std::vector<char>& payload,
       DeltaArchiveManifest* manifest,
-      uint64_t* metadata_size,
-      ActionExitCode* error);
+      uint64_t* metadata_size);
 
  private:
   DISALLOW_IMPLICIT_CONSTRUCTORS(DeltaMetadata);

--- a/src/update_engine/install_plan.cc
+++ b/src/update_engine/install_plan.cc
@@ -22,6 +22,7 @@ InstallPlan::InstallPlan(bool is_resume,
       payload_size(payload_size),
       payload_hash(payload_hash),
       install_path(install_path),
+      kernel_path(utils::BootKernelName(install_path)),
       rootfs_size(0) {}
 
 InstallPlan::InstallPlan() : is_resume(false),
@@ -34,7 +35,8 @@ bool InstallPlan::operator==(const InstallPlan& that) const {
           (download_url == that.download_url) &&
           (payload_size == that.payload_size) &&
           (payload_hash == that.payload_hash) &&
-          (install_path == that.install_path));
+          (install_path == that.install_path) &&
+          (kernel_path == that.kernel_path));
 }
 
 bool InstallPlan::operator!=(const InstallPlan& that) const {
@@ -47,7 +49,8 @@ void InstallPlan::Dump() const {
             << ", url: " << download_url
             << ", payload size: " << payload_size
             << ", payload hash: " << payload_hash
-            << ", install_path: " << install_path;
+            << ", install_path: " << install_path
+            << ", kernel_path: " << kernel_path;
 }
 
 }  // namespace chromeos_update_engine

--- a/src/update_engine/install_plan.h
+++ b/src/update_engine/install_plan.h
@@ -33,7 +33,8 @@ struct InstallPlan {
 
   uint64_t payload_size;                 // size of the payload
   std::string payload_hash ;             // SHA256 hash of the payload
-  std::string install_path;              // path to install device
+  std::string install_path;              // path to main partition device
+  std::string kernel_path;               // path to kernel image
 
   // The fields below are used for rootfs verification. The flow is:
   //

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -75,13 +75,13 @@ bool PayloadProcessor::Write(const void* bytes, size_t count,
   buffer_.insert(buffer_.end(), c_bytes, c_bytes + count);
 
   if (!manifest_valid_) {
-    DeltaMetadata::ParseResult result = DeltaMetadata::ParsePayload(
-        buffer_, &manifest_, &manifest_metadata_size_, error);
-    switch (result) {
-      case DeltaMetadata::kParseError: return false;
-      case DeltaMetadata::kParseInsufficientData: return true;
-      case DeltaMetadata::kParseSuccess: break;
-    }
+    *error = DeltaMetadata::ParsePayload(
+        buffer_, &manifest_, &manifest_metadata_size_);
+    if (*error == kActionCodeDownloadIncomplete) {
+      *error = kActionCodeSuccess;
+      return true;
+    } else if (*error != kActionCodeSuccess)
+      return false;
 
     // Remove protobuf and header info from buffer_, so buffer_ contains
     // just data blobs

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -84,42 +84,13 @@ bool PayloadProcessor::Write(const void* bytes, size_t count,
   }
 
   while (next_operation_num_ < num_total_operations_) {
-    const InstallOperation &op =
-        manifest_.partition_operations(next_operation_num_);
-
-    if (op.data_length() && op.data_offset() != buffer_offset_) {
-      LOG(ERROR) << "Operation " << next_operation_num_
-                 << " skipped to unexpected data offset " << op.data_offset()
-                 << ", expected " << buffer_offset_;
-      *error = kActionCodeDownloadOperationExecutionError;
-      return false;
-    }
-
-    if (op.data_length() > buffer_.size()) {
-      // This means we don't have enough bytes received yet to carry out the
-      // next operation.
+    *error = PerformOperation();
+    if (*error == kActionCodeDownloadIncomplete) {
+      *error = kActionCodeSuccess;
       return true;
-    }
-
-    // Makes sure we unblock exit when this operation completes.
-    ScopedTerminatorExitUnblocker exit_unblocker =
-        ScopedTerminatorExitUnblocker();  // Avoids a compiler unused var bug.
-
-    *error = delta_performer_.PerformOperation(op, buffer_);
-    if (*error != kActionCodeSuccess) {
-      LOG(ERROR) << "Aborting install procedure at operation "
-                 << num_total_operations_;
+    } else if (*error != kActionCodeSuccess) {
       return false;
     }
-
-    buffer_offset_ += op.data_length();
-    DiscardBufferHeadBytes(op.data_length());
-
-    next_operation_num_++;
-    LOG(INFO) << "Completed " << next_operation_num_ << "/"
-              << num_total_operations_ << " operations ("
-              << (next_operation_num_ * 100 / num_total_operations_) << "%)";
-    CheckpointUpdateProgress();
   }
 
   // Make sure the operations consumed exactly the right amount of data.
@@ -167,6 +138,45 @@ ActionExitCode PayloadProcessor::LoadManifest() {
   if (next_operation_num_ > 0)
     LOG(INFO) << "Resuming after " << next_operation_num_ << " operations";
   LOG(INFO) << "Starting to apply update payload operations";
+
+  return kActionCodeSuccess;
+}
+
+ActionExitCode PayloadProcessor::PerformOperation() {
+  DCHECK(next_operation_num_ < num_total_operations_);
+
+  const InstallOperation &op =
+      manifest_.partition_operations(next_operation_num_);
+
+  if (op.data_length() && op.data_offset() != buffer_offset_) {
+    LOG(ERROR) << "Operation " << next_operation_num_
+               << " skipped to unexpected data offset " << op.data_offset()
+               << ", expected " << buffer_offset_;
+    return kActionCodeDownloadOperationExecutionError;
+  }
+
+  if (op.data_length() > buffer_.size())
+    return kActionCodeDownloadIncomplete;
+
+  // Makes sure we unblock exit when this operation completes.
+  ScopedTerminatorExitUnblocker exit_unblocker =
+      ScopedTerminatorExitUnblocker();  // Avoids a compiler unused var bug.
+
+  ActionExitCode error = delta_performer_.PerformOperation(op, buffer_);
+  if (error != kActionCodeSuccess) {
+    LOG(ERROR) << "Aborting install procedure at operation "
+               << next_operation_num_;
+    return error;
+  }
+
+  buffer_offset_ += op.data_length();
+  DiscardBufferHeadBytes(op.data_length());
+  next_operation_num_++;
+
+  LOG(INFO) << "Completed " << next_operation_num_ << "/"
+            << num_total_operations_ << " operations ("
+            << (next_operation_num_ * 100 / num_total_operations_) << "%)";
+  CheckpointUpdateProgress();
 
   return kActionCodeSuccess;
 }

--- a/src/update_engine/payload_processor.h
+++ b/src/update_engine/payload_processor.h
@@ -98,6 +98,9 @@ class PayloadProcessor : public FileWriter {
   // the manifest. Result may be kActionCodeDownloadIncomplete.
   ActionExitCode LoadManifest();
 
+  // Execute a single operation. Result may be kActionCodeDownloadIncomplete.
+  ActionExitCode PerformOperation();
+
   // Verifies that the expected source partition hash (if present) match the
   // hash for the current partition. Returns true if there're no expected
   // hash in the payload (e.g., if it's a new-style full update) or if the

--- a/src/update_engine/payload_processor.h
+++ b/src/update_engine/payload_processor.h
@@ -94,6 +94,10 @@ class PayloadProcessor : public FileWriter {
   }
 
  private:
+  // Parses the manifest and finishes any initialization that needs info from
+  // the manifest. Result may be kActionCodeDownloadIncomplete.
+  ActionExitCode LoadManifest();
+
   // Verifies that the expected source partition hash (if present) match the
   // hash for the current partition. Returns true if there're no expected
   // hash in the payload (e.g., if it's a new-style full update) or if the

--- a/src/update_engine/payload_signer.cc
+++ b/src/update_engine/payload_signer.cc
@@ -153,10 +153,10 @@ bool PayloadSigner::LoadPayload(const string& payload_path,
   // Loads the payload and parses the manifest.
   TEST_AND_RETURN_FALSE(utils::ReadFile(payload_path, &payload));
   LOG(INFO) << "Payload size: " << payload.size();
-  ActionExitCode error = kActionCodeSuccess;
-  TEST_AND_RETURN_FALSE(DeltaMetadata::ParsePayload(
-      payload, out_manifest, out_metadata_size, &error) ==
-                        DeltaMetadata::kParseSuccess);
+  ActionExitCode error = DeltaMetadata::ParsePayload(
+      payload, out_manifest, out_metadata_size);
+  if (error != kActionCodeSuccess)
+    return false;
   LOG(INFO) << "Metadata size: " << *out_metadata_size;
   out_payload->swap(payload);
   return true;

--- a/src/update_engine/payload_state.cc
+++ b/src/update_engine/payload_state.cc
@@ -182,6 +182,7 @@ void PayloadState::UpdateFailed(ActionExitCode error) {
     case kActionCodeResumedFlag:                        // not an error code
     case kActionCodeTestImageFlag:                      // not an error code
     case kActionCodeTestOmahaUrlFlag:                   // not an error code
+    case kActionCodeDownloadIncomplete:                 // not an error code
     case kSpecialFlags:                                 // not an error code
       // These shouldn't happen. Enumerating these  explicitly here so that we
       // can let the compiler warn about new error codes that are added to

--- a/src/update_engine/update_metadata.proto
+++ b/src/update_engine/update_metadata.proto
@@ -124,6 +124,19 @@ message BlobInfo {
   optional bytes hash = 2;
 }
 
+// Manifest defines the update procedure for any files that exist
+message InstallBlob {
+  enum Type {
+    KERNEL = 0;  // A kernel image to install to the boot partition.
+  }
+  required Type type = 1;
+
+  repeated InstallOperation operations = 2;
+
+  optional BlobInfo old_info = 3;
+  optional BlobInfo new_info = 4;
+}
+
 message DeltaArchiveManifest {
   // The update procedure for the main partition (USR-A or USR-B). Once
   // complete it should match the hash specified in new_partition_info.
@@ -169,4 +182,10 @@ message DeltaArchiveManifest {
   // Partition data that can be used to validate the update.
   optional BlobInfo old_partition_info = 8;
   optional BlobInfo new_partition_info = 9;
+
+  // In addition to the partition update, process updates for additional
+  // files, such as kernels. Versions of update_engine that can interpret
+  // this list *MUST* ignore noop_operations and properly account for the
+  // signature data at the end of the payload.
+  repeated InstallBlob blobs = 10;
 }

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -775,6 +775,8 @@ string CodeToString(ActionExitCode code) {
       return "kActionCodeOmahaUpdateDeferredForBackoff";
     case kActionCodePostinstallPowerwashError:
       return "kActionCodePostinstallPowerwashError";
+    case kActionCodeDownloadIncomplete:
+      return "kActionCodeDownloadIncomplete";
     case kActionCodeOmahaRequestHTTPResponseBase:
       return "kActionCodeOmahaRequestHTTPResponseBase";
     case kActionCodeResumedFlag:


### PR DESCRIPTION
A bit of refactoring and updates the metadata protobuf format for kernels.

I want InstallBlob to be extensible so adding new values to the enum needs to be safe but I am not sure what will happen if old code gets a new enum value. Whether it is graceful or aborts might even depend on whether the code is built with -DNDEBUG or not. Need to test to confirm... :-/