### PR TITLE
use 'blkid' instead of 'lsblk' to get partition label

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -13,7 +13,7 @@ INSTALL_DEV="$1"
 APP_ID="${2:-"{e96281a6-d1af-4bde-9a0a-97b76e56dc57}"}"
 
 # Figure out if the slot id is A or B
-INSTALL_LABEL=$(lsblk -n -o PARTLABEL "${INSTALL_DEV}")
+INSTALL_LABEL=$(blkid -o value -s PARTLABEL "${INSTALL_DEV}")
 case "${INSTALL_LABEL}" in
     ROOT-A|USR-A)
         SLOT=A;;


### PR DESCRIPTION
When running an update on slow media, i.e. USB sticks
the FilesystemCopierAction seems to clear the partition label for a brief
moment. `lsblk` then retrieves an empty label in postinst stage, causing
a failure. Interestingly, running `gdisk` on the affected media and just
printing the partition table "refreshes" the label for subsequent `lsblk`
runs.

Replacing `lsblk` with `blkid` returns the correct label every time.