### PR TITLE
coreos-postinst: revert app-id checking

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -10,7 +10,6 @@ OEM_MNT="/usr/share/oem"
 
 INSTALL_MNT=$(dirname "$0")
 INSTALL_DEV="$1"
-APP_ID="${2:-"{e96281a6-d1af-4bde-9a0a-97b76e56dc57}"}"
 
 # Figure out if the slot id is A or B
 INSTALL_LABEL=$(blkid -o value -s PARTLABEL "${INSTALL_DEV}")
@@ -79,14 +78,11 @@ if grep -q cros_legacy /proc/cmdline; then
     fi
 fi
 
-# Check if we're running on an old-style app config
-if [[ "$APP_ID" = "{e96281a6-d1af-4bde-9a0a-97b76e56dc57}" ]]; then
-    # Copy the kernel to the ESP for new-style boots
-    if [[ -f "${ESP_MNT}/coreos/vmlinuz-a" ]]; then
-	# kernel names are in lower case, ${SLOT,,} converts the slot name
-	cp -v "${INSTALL_MNT}/boot/vmlinuz" \
-	   "${ESP_MNT}/coreos/vmlinuz-${SLOT,,}"
-    fi
+# Copy the kernel to the ESP for new-style boots
+if [[ -f "${ESP_MNT}/coreos/vmlinuz-a" ]]; then
+    # kernel names are in lower case, ${SLOT,,} converts the slot name
+    cp -v "${INSTALL_MNT}/boot/vmlinuz" \
+       "${ESP_MNT}/coreos/vmlinuz-${SLOT,,}"
 fi
 
 # If the OEM provides a hook, call it
@@ -140,5 +136,4 @@ call_cgpt prioritize "${INSTALL_DEV}"
 call_cgpt show "${INSTALL_DEV}"
 
 cat "${INSTALL_MNT}/share/coreos/release"
-echo "COREOS_RELEASE_APPID=$APP_ID"
 echo "Setup ${INSTALL_LABEL} (${INSTALL_DEV}) for next boot."

--- a/src/update_engine/postinstall_runner_action.cc
+++ b/src/update_engine/postinstall_runner_action.cc
@@ -18,10 +18,6 @@ namespace {
 const char kPostinstallScript[] = "/postinst";
 }
 
-PostinstallRunnerAction::PostinstallRunnerAction(
-    std::string app_id)
-    : app_id_(std::move(app_id)) {}
-
 void PostinstallRunnerAction::PerformAction() {
   CHECK(HasInputObject());
   const InstallPlan install_plan = GetInputObject();
@@ -61,7 +57,6 @@ void PostinstallRunnerAction::PerformAction() {
   vector<string> command;
   command.push_back(temp_rootfs_dir_ + kPostinstallScript);
   command.push_back(install_device);
-  command.push_back(app_id_);
   if (!Subprocess::Get().Exec(command, StaticCompletePostinstall, this)) {
     CompletePostinstall(1);
   }

--- a/src/update_engine/postinstall_runner_action.h
+++ b/src/update_engine/postinstall_runner_action.h
@@ -29,7 +29,7 @@ class ActionTraits<PostinstallRunnerAction> {
 
 class PostinstallRunnerAction : public Action<PostinstallRunnerAction> {
  public:
-  explicit PostinstallRunnerAction(std::string app_id);
+  PostinstallRunnerAction() {}
   typedef ActionTraits<PostinstallRunnerAction>::InputObjectType
       InputObjectType;
   typedef ActionTraits<PostinstallRunnerAction>::OutputObjectType
@@ -51,7 +51,6 @@ class PostinstallRunnerAction : public Action<PostinstallRunnerAction> {
                                         void* p);
 
   std::string temp_rootfs_dir_;
-  std::string app_id_;
 
   DISALLOW_COPY_AND_ASSIGN(PostinstallRunnerAction);
 };

--- a/src/update_engine/postinstall_runner_action_unittest.cc
+++ b/src/update_engine/postinstall_runner_action_unittest.cc
@@ -13,7 +13,6 @@
 #include <gtest/gtest.h>
 
 #include "strings/string_printf.h"
-#include "update_engine/omaha_request_params.h"
 #include "update_engine/postinstall_runner_action.h"
 #include "update_engine/test_utils.h"
 #include "update_engine/utils.h"
@@ -141,7 +140,7 @@ void PostinstallRunnerActionTest::DoTest(bool do_losetup, int err_code) {
   InstallPlan install_plan;
   install_plan.install_path = dev;
   feeder_action.set_obj(install_plan);
-  PostinstallRunnerAction runner_action(OmahaRequestParams::kAppId);
+  PostinstallRunnerAction runner_action;
   BondActions(&feeder_action, &runner_action);
   ObjectCollectorAction<InstallPlan> collector_action;
   BondActions(&runner_action, &collector_action);
@@ -185,7 +184,7 @@ void PostinstallRunnerActionTest::DoTest(bool do_losetup, int err_code) {
 // Death tests don't seem to be working on Hardy
 TEST_F(PostinstallRunnerActionTest, DISABLED_RunAsRootDeathTest) {
   ASSERT_EQ(0, getuid());
-  PostinstallRunnerAction runner_action(OmahaRequestParams::kAppId);
+  PostinstallRunnerAction runner_action;
   ASSERT_DEATH({ runner_action.TerminateProcessing(); },
                "postinstall_runner_action.h:.*] Check failed");
 }

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -198,7 +198,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   shared_ptr<FilesystemCopierAction> filesystem_verifier_action(
       new FilesystemCopierAction(true));
   shared_ptr<PostinstallRunnerAction> postinstall_runner_action(
-      new PostinstallRunnerAction(omaha_request_params_->app_id()));
+      new PostinstallRunnerAction);
   shared_ptr<OmahaRequestAction> update_complete_action(
       new OmahaRequestAction(system_state_,
                              new OmahaEvent(OmahaEvent::kTypeUpdateComplete),

--- a/src/update_engine/update_attempter_unittest.cc
+++ b/src/update_engine/update_attempter_unittest.cc
@@ -175,7 +175,7 @@ TEST_F(UpdateAttempterTest, GetErrorCodeForActionTest) {
   FilesystemCopierAction filesystem_copier_action(false);
   EXPECT_EQ(kActionCodeFilesystemCopierError,
             GetErrorCodeForAction(&filesystem_copier_action, kActionCodeError));
-  PostinstallRunnerAction postinstall_runner_action(OmahaRequestParams::kAppId);
+  PostinstallRunnerAction postinstall_runner_action;
   EXPECT_EQ(kActionCodePostinstallRunnerError,
             GetErrorCodeForAction(&postinstall_runner_action,
                                   kActionCodeError));


### PR DESCRIPTION
This is left over from our previous scheme of using a new app-id to
determine how the kernel would get updated. No longer applicable.

update_engine's behavior now should match that of the
older version of update_engine we are still shipping in CoreOS.

This reverts commits 7730651c57ec09f1d20ed10ad5835b6ebe70f79a, be204cd, 7f342ac,
and partially reverts f4157edb80cd4169caef317da6438d4dfa901018,