### PR TITLE
update_metadata: drop the term Blob in structure names

### DIFF
--- a/src/update_engine/delta_diff_generator.cc
+++ b/src/update_engine/delta_diff_generator.cc
@@ -536,7 +536,7 @@ bool DeltaDiffGenerator::ReadFileToDiff(
 }
 
 bool DeltaDiffGenerator::InitializePartitionInfo(const string& partition,
-                                                 BlobInfo* info) {
+                                                 InstallInfo* info) {
   int64_t size = 0;
   int block_count = 0, block_size = 0;
   TEST_AND_RETURN_FALSE(utils::GetFilesystemSize(partition,

--- a/src/update_engine/delta_diff_generator.h
+++ b/src/update_engine/delta_diff_generator.h
@@ -219,7 +219,7 @@ class DeltaDiffGenerator {
   static bool IsNoopOperation(const InstallOperation& op);
 
   static bool InitializePartitionInfo(const std::string& partition,
-                                      BlobInfo* info);
+                                      InstallInfo* info);
 
   // Runs the bsdiff tool on two files and returns the resulting delta in
   // |out|. Returns true on success.

--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -179,7 +179,7 @@ void ApplyDelta() {
       << "Failed to initialize preferences.";
   // Get original checksums
   LOG(INFO) << "Calculating original checksums";
-  BlobInfo root_info;
+  InstallInfo root_info;
   CHECK(DeltaDiffGenerator::InitializePartitionInfo(FLAGS_old_image,
                                                     &root_info));
   install_plan.rootfs_hash.assign(root_info.hash().begin(),

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -31,7 +31,7 @@ namespace {
 const int kUpdateStateOperationInvalid = -1;
 const int kMaxResumedUpdateFailures = 10;
 
-void LogPartitionInfoHash(const BlobInfo& info, const string& tag) {
+void LogPartitionInfoHash(const InstallInfo& info, const string& tag) {
   string sha256;
   if (OmahaHashCalculator::Base64Encode(info.hash().data(),
                                         info.hash().size(),
@@ -315,7 +315,7 @@ bool PayloadProcessor::VerifySourcePartition() {
   CHECK(manifest_valid_);
   CHECK(install_plan_);
   if (manifest_.has_old_partition_info()) {
-    const BlobInfo& info = manifest_.old_partition_info();
+    const InstallInfo& info = manifest_.old_partition_info();
     bool valid =
         !install_plan_->rootfs_hash.empty() &&
         install_plan_->rootfs_hash.size() == info.hash().size() &&

--- a/src/update_engine/update_metadata.proto
+++ b/src/update_engine/update_metadata.proto
@@ -117,15 +117,17 @@ message Signatures {
   repeated Signature signatures = 1;
 }
 
-// BlobInfo is used to validate the source prior to the update or
+// Info is used to validate the source prior to the update or
 // the destination after the list of InstallOperations has run.
-message BlobInfo {
+
+message InstallInfo {
   optional uint64 size = 1;
   optional bytes hash = 2;
 }
 
-// Manifest defines the update procedure for any files that exist
-message InstallBlob {
+// InstallProcedure defines the update procedure for a single file or block
+// device (except for /usr which is in DeltaArchiveManifest).
+message InstallProcedure {
   enum Type {
     KERNEL = 0;  // A kernel image to install to the boot partition.
   }
@@ -133,8 +135,8 @@ message InstallBlob {
 
   repeated InstallOperation operations = 2;
 
-  optional BlobInfo old_info = 3;
-  optional BlobInfo new_info = 4;
+  optional InstallInfo old_info = 3;
+  optional InstallInfo new_info = 4;
 }
 
 message DeltaArchiveManifest {
@@ -180,12 +182,12 @@ message DeltaArchiveManifest {
   // Deprecated IDs 6 and 7, do not reuse.
 
   // Partition data that can be used to validate the update.
-  optional BlobInfo old_partition_info = 8;
-  optional BlobInfo new_partition_info = 9;
+  optional InstallInfo old_partition_info = 8;
+  optional InstallInfo new_partition_info = 9;
 
   // In addition to the partition update, process updates for additional
   // files, such as kernels. Versions of update_engine that can interpret
   // this list *MUST* ignore noop_operations and properly account for the
   // signature data at the end of the payload.
-  repeated InstallBlob blobs = 10;
+  repeated InstallProcedure procedures = 10;
 }


### PR DESCRIPTION
@mjg59 pointed out Blob was a confusing choice because that term is used
in many other contexts in this code base. Instead match the existing
`InstallOperation` name and use `InstallInfo` and `InstallProcedure`.