### PR TITLE
generate_delta_main: fix usage of the payload processor

### DIFF
--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -196,7 +196,7 @@ void ApplyDelta() {
     CHECK(utils::PReadAll(fd, &buf[0], buf.size(), offset, &bytes_read));
     if (bytes_read == 0)
       break;
-    CHECK_EQ(performer.Write(&buf[0], bytes_read), bytes_read);
+    CHECK(performer.Write(&buf[0], bytes_read));
   }
   CHECK_EQ(performer.Close(), 0);
   PayloadProcessor::ResetUpdateProgress(&prefs, false);


### PR DESCRIPTION
Long standing bug: Write returns bool, not an errno.