### PR TITLE
update_engine: change default log target to stderr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,19 @@ PKG_CHECK_MODULES([DEPS],
                    libxml-2.0
                    protobuf])
 
+# Make sure logging can be configured with command line flags. If glog
+# was built with gflags support it will include the gflags header.
+AC_MSG_CHECKING([glog uses gflags])
+AC_LANG_PUSH([C++])
+AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <glog/logging.h>
+                                    #ifndef DECLARE_VARIABLE
+                                    #error MISSING_GFLAGS
+                                    #endif]])],
+                  [AC_MSG_RESULT([yes])],
+                  [AC_MSG_RESULT([no])
+                   AC_MSG_ERROR([*** glog missing gflags support])])
+AC_LANG_POP([C++])
+
 AC_ARG_ENABLE([delta_generator],
               [AS_HELP_STRING([--enable-delta_generator],
                               [build delta_generator])],

--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -204,10 +204,14 @@ void ApplyDelta() {
 }
 
 int Main(int argc, char** argv) {
+  // Disable glog's default behavior of logging to files.
+  FLAGS_logtostderr = true;
   GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+
   Terminator::Init();
   Subprocess::Init();
-  google::InitGoogleLogging(argv[0]);
+
   if (!FLAGS_signature_size.empty()) {
     bool work_done = false;
     if (!FLAGS_out_hash_file.empty()) {

--- a/src/update_engine/main.cc
+++ b/src/update_engine/main.cc
@@ -74,11 +74,15 @@ void SetupDbusService(UpdateEngineService* service) {
 }  // namespace chromeos_update_engine
 
 int main(int argc, char** argv) {
+  // Disable glog's default behavior of logging to files.
+  FLAGS_logtostderr = true;
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+
   dbus_threads_init_default();
   chromeos_update_engine::Terminator::Init();
   chromeos_update_engine::Subprocess::Init();
-  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
-  google::InitGoogleLogging(argv[0]);
+
   if (!FLAGS_foreground)
     PLOG_IF(FATAL, daemon(0, 0) == 1) << "daemon() failed";
 

--- a/src/update_engine/test_http_server.cc
+++ b/src/update_engine/test_http_server.cc
@@ -513,6 +513,10 @@ void HandleConnection(int fd) {
 using namespace chromeos_update_engine;
 
 int main(int argc, char** argv) {
+  // Disable glog's default behavior of logging to files.
+  FLAGS_logtostderr = true;
+  google::InitGoogleLogging(argv[0]);
+
   // Ignore SIGPIPE on write() to sockets.
   signal(SIGPIPE, SIG_IGN);
 

--- a/src/update_engine/testrunner.cc
+++ b/src/update_engine/testrunner.cc
@@ -12,6 +12,10 @@
 #include "update_engine/terminator.h"
 
 int main(int argc, char **argv) {
+  // Disable glog's default behavior of logging to files.
+  FLAGS_logtostderr = true;
+  google::InitGoogleLogging(argv[0]);
+
   dbus_threads_init_default();
   // TODO(garnold) temporarily cause the unittest binary to exit with status
   // code 2 upon catching a SIGTERM. This will help diagnose why the unittest
@@ -20,7 +24,6 @@ int main(int argc, char **argv) {
   // terminator_unittest.cc.
   chromeos_update_engine::Terminator::Init(2);
   chromeos_update_engine::Subprocess::Init();
-  google::InitGoogleLogging(argv[0]);
   LOG(INFO) << "initializing gtest";
   ::testing::InitGoogleTest(&argc, argv);
   LOG(INFO) << "running unit tests";


### PR DESCRIPTION
By default glog outputs a number of log files to /tmp and very little to
stderr which is never what we want in CoreOS. Add an explicit check that
glog was built with gflags support so logging options are available.