### PR TITLE
test_utils: use ext2 instead of ext3

### DIFF
--- a/src/update_engine/ext2_metadata_unittest.cc
+++ b/src/update_engine/ext2_metadata_unittest.cc
@@ -101,13 +101,12 @@ TEST_F(Ext2MetadataTest, RunAsRootReadMetadata) {
                                               fd,
                                               &data_file_size));
 
-  // There are 12 metadata that we look for:
+  // The metadata that we look for:
   //   - Block group 0 metadata (superblock, group descriptor, bitmaps, etc)
   //       - Chunk 0, 1, 2, 3
   //   - Block group 1 metadata
   //       - Chunk 0, 1, 2, 3
   //   - Root directory (inode 2)
-  //   - Journal (inode 8)
   //   - lost+found directory (inode 11)
   //   - test_file indirect block (inode 12)
   struct {
@@ -136,7 +135,6 @@ TEST_F(Ext2MetadataTest, RunAsRootReadMetadata) {
        {"<fs-bg-1-8-metadata>", 33600, 104},
        {"<fs-bg-1-9-metadata>", 33704, 107},
        {"<fs-inode-2-metadata>", -1, 1},
-       {"<fs-inode-8-metadata>", -1, 4101},
        {"<fs-inode-11-metadata>", -1, 4},
        {"<fs-inode-12-metadata>", -1, 1}};
 

--- a/src/update_engine/postinstall_runner_action_unittest.cc
+++ b/src/update_engine/postinstall_runner_action_unittest.cc
@@ -111,10 +111,7 @@ void PostinstallRunnerActionTest::DoTest(bool do_losetup, int err_code) {
 
   // put a postinst script in
   string script = StringPrintf("#!/bin/bash\n"
-                               "mount | grep au_postint_mount | grep ext2\n"
-                               "if [ $? -eq 0 ]; then\n"
-                               "  touch %s/postinst_called\n"
-                               "fi\n",
+                               "touch %s/postinst_called\n",
                                cwd.c_str());
   if (err_code) {
     script = StringPrintf("#!/bin/bash\nexit %d", err_code);

--- a/src/update_engine/test_utils.cc
+++ b/src/update_engine/test_utils.cc
@@ -189,7 +189,7 @@ void CreateEmptyExtImageAtPath(const string& path,
   EXPECT_EQ(0, System(StringPrintf("dd if=/dev/zero of=%s"
                                    " seek=%zu bs=1 count=1",
                                    path.c_str(), size)));
-  EXPECT_EQ(0, System(StringPrintf("mkfs.ext3 -b %d -F %s",
+  EXPECT_EQ(0, System(StringPrintf("mkfs.ext2 -b %d -F %s",
                                    block_size, path.c_str())));
 }
 
@@ -198,7 +198,7 @@ void CreateExtImageAtPath(const string& path, vector<string>* out_paths) {
   EXPECT_EQ(0, System(StringPrintf("dd if=/dev/zero of=%s"
                                    " seek=10485759 bs=1 count=1",
                                    path.c_str())));
-  EXPECT_EQ(0, System(StringPrintf("mkfs.ext3 -b 4096 -F %s", path.c_str())));
+  EXPECT_EQ(0, System(StringPrintf("mkfs.ext2 -b 4096 -F %s", path.c_str())));
   EXPECT_EQ(0, System(StringPrintf("mkdir -p %s", kMountPath)));
   EXPECT_EQ(0, System(StringPrintf("mount -o loop %s %s", path.c_str(),
                                    kMountPath)));

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -489,7 +489,7 @@ const string BootKernelName(const std::string& boot_device) {
 bool MountFilesystem(const string& device,
                      const string& mountpoint,
                      unsigned long mountflags) {
-  int rc = mount(device.c_str(), mountpoint.c_str(), "ext3", mountflags, NULL);
+  int rc = mount(device.c_str(), mountpoint.c_str(), "ext2", mountflags, NULL);
   if (rc < 0) {
     string msg = ErrnoNumberAsString(errno);
     LOG(ERROR) << "Unable to mount destination device: " << msg << ". "


### PR DESCRIPTION
Images should never be generated from a journaled filesystem. Attempting
to shove the 4MB journal in the test filesystem normally isn't a big
deal but sometimes it appears to tickle something problematic in the
bsdiff algorithm, taking as long as 15-20 minutes to run.

So lets just not do that shall we? :-P