### PR TITLE
download_action: remove unthrottled download progress logging

### DIFF
--- a/src/update_engine/download_action.cc
+++ b/src/update_engine/download_action.cc
@@ -78,11 +78,6 @@ void DownloadAction::ReceivedBytes(HttpFetcher *fetcher,
                                    const char* bytes,
                                    int length) {
   bytes_downloaded_ += length;
-  uint64_t pct = 0;
-  if (install_plan_.payload_size)
-    pct = (bytes_downloaded_ * 100) / install_plan_.payload_size;
-  LOG(INFO) << "Downloaded " << bytes_downloaded_ << "/"
-            << install_plan_.payload_size << " bytes (" << pct << "%)";
   if (delegate_)
     delegate_->BytesReceived(length,
                              bytes_downloaded_,

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -400,6 +400,8 @@ void UpdateAttempter::BytesReceived(uint64_t received,
       pct - download_progress_ >= kDeltaPercent ||
       steady_clock::now() - last_notify_time_ >= std::chrono::seconds(10)) {
     download_progress_ = pct;
+    LOG(INFO) << "Downloaded " << progress << "/" << total
+              << " bytes (" << static_cast<int>(100.0*pct) << "%)";
     SetStatusAndNotify(UPDATE_STATUS_DOWNLOADING, kUpdateNoticeUnspecified);
   }
 }


### PR DESCRIPTION
During previous refactoring I removed some rather complicated throttling
logic around this log line. Also, the function calls another in
update_attempter (aka delegate) which already includes some a throttle
for dbus events so lets just log from there instead.