### PR TITLE
Add kernel support to delta_generator

### DIFF
--- a/src/update_engine/delta_diff_generator.cc
+++ b/src/update_engine/delta_diff_generator.cc
@@ -369,10 +369,98 @@ void InstallOperationsToManifest(
   }
 }
 
+// Adds all |kernel_ops| to |manifest|. Filters out no-op operations.
+// Computes hash for old and new kernel images.
+bool KernelProcedureToManifest(
+    const string& old_kernel_path,
+    const string& new_kernel_path,
+    const vector<InstallOperation>& kernel_ops,
+    DeltaArchiveManifest* manifest) {
+  DCHECK(!kernel_ops.empty());
+  DCHECK(!new_kernel_path.empty());
+
+  InstallProcedure* proc = manifest->add_procedures();
+  proc->set_type(InstallProcedure_Type_KERNEL);
+  for (const InstallOperation& add_op : kernel_ops) {
+    if (DeltaDiffGenerator::IsNoopOperation(add_op)) {
+      continue;
+    }
+    InstallOperation* op = proc->add_operations();
+    *op = add_op;
+  }
+
+  if (!old_kernel_path.empty()) {
+    TEST_AND_RETURN_FALSE(
+        DeltaDiffGenerator::InitializeInfo(old_kernel_path,
+                                           proc->mutable_old_info()));
+  }
+  TEST_AND_RETURN_FALSE(
+      DeltaDiffGenerator::InitializeInfo(new_kernel_path,
+                                         proc->mutable_new_info()));
+  return true;
+}
+
+// Create dummy operations to cover data required by extra InstallProcedures
+// in the noop_operations list for compatibility with old versions that did
+// not support the new procedures.
+void ProceduresToNoops(DeltaArchiveManifest* manifest) {
+  for (const InstallProcedure& proc : manifest->procedures()) {
+    for (const InstallOperation& op : proc.operations()) {
+      InstallOperation* noop = manifest->add_noop_operations();
+      noop->set_type(InstallOperation_Type_REPLACE);
+      noop->set_data_offset(op.data_offset());
+      noop->set_data_length(op.data_length());
+      // Tell the dummy op to write this data to a big sparse hole
+      Extent* extent = noop->add_dst_extents();
+      extent->set_start_block(kSparseHole);
+      extent->set_num_blocks((op.data_length() + kBlockSize - 1) / kBlockSize);
+    }
+  }
+}
+
 void CheckGraph(const Graph& graph) {
   for (const Vertex& v : graph) {
     CHECK(v.op.has_type());
   }
+}
+
+// Delta compresses a kernel partition |new_kernel| with knowledge of the
+// old kernel partition |old_kernel|. If |old_kernel| is an empty string,
+// generates a full update of the partition.
+bool DeltaCompressKernel(
+    const string& old_kernel,
+    const string& new_kernel,
+    vector<InstallOperation>* ops,
+    int blobs_fd,
+    off_t* blobs_length) {
+  LOG(INFO) << "Delta compressing kernel partition...";
+  LOG_IF(INFO, old_kernel.empty()) << "Generating full kernel update...";
+
+  // Add a new install operation
+  ops->resize(1);
+  InstallOperation* op = &(*ops)[0];
+
+  vector<char> data;
+  TEST_AND_RETURN_FALSE(
+      DeltaDiffGenerator::ReadFileToDiff(old_kernel,
+                                         new_kernel,
+                                         true, // bsdiff_allowed
+                                         &data,
+                                         op,
+                                         false));
+
+  // Write the data
+  if (op->type() != InstallOperation_Type_MOVE) {
+    op->set_data_offset(*blobs_length);
+    op->set_data_length(data.size());
+  }
+
+  TEST_AND_RETURN_FALSE(utils::WriteAll(blobs_fd, &data[0], data.size()));
+  *blobs_length += data.size();
+
+  LOG(INFO) << "Done delta compressing kernel partition: "
+            << kInstallOperationTypes[op->type()];
+  return true;
 }
 
 struct DeltaObject {
@@ -532,17 +620,16 @@ bool DeltaDiffGenerator::ReadFileToDiff(
   return true;
 }
 
-bool DeltaDiffGenerator::InitializePartitionInfo(const string& partition,
-                                                 InstallInfo* info) {
+bool DeltaDiffGenerator::InitializeInfo(const string& path, InstallInfo* info) {
   off_t size = 0;
-  TEST_AND_RETURN_FALSE(utils::GetDeviceSize(partition, &size));
+  TEST_AND_RETURN_FALSE(utils::GetDeviceSize(path, &size));
   info->set_size(size);
   OmahaHashCalculator hasher;
-  TEST_AND_RETURN_FALSE(hasher.UpdateFile(partition, size) == size);
+  TEST_AND_RETURN_FALSE(hasher.UpdateFile(path, size) == size);
   TEST_AND_RETURN_FALSE(hasher.Finalize());
   const vector<char>& hash = hasher.raw_hash();
   info->set_hash(hash.data(), hash.size());
-  LOG(INFO) << partition << ": size=" << size << " hash=" << hasher.hash();
+  LOG(INFO) << path << ": size=" << size << " hash=" << hasher.hash();
   return true;
 }
 
@@ -550,11 +637,11 @@ bool InitializePartitionInfos(const string& old_rootfs,
                               const string& new_rootfs,
                               DeltaArchiveManifest& manifest) {
   if (!old_rootfs.empty()) {
-    TEST_AND_RETURN_FALSE(DeltaDiffGenerator::InitializePartitionInfo(
+    TEST_AND_RETURN_FALSE(DeltaDiffGenerator::InitializeInfo(
         old_rootfs,
         manifest.mutable_old_partition_info()));
   }
-  TEST_AND_RETURN_FALSE(DeltaDiffGenerator::InitializePartitionInfo(
+  TEST_AND_RETURN_FALSE(DeltaDiffGenerator::InitializeInfo(
       new_rootfs,
       manifest.mutable_new_partition_info()));
   return true;
@@ -1055,6 +1142,31 @@ bool DeltaDiffGenerator::NoTempBlocksRemain(const Graph& graph) {
   return true;
 }
 
+static bool ReorderProcedureDataBlobs(
+    google::protobuf::RepeatedPtrField<InstallOperation>* ops,
+    int in_fd,
+    DirectFileWriter* writer,
+    uint64_t* written) {
+  for (InstallOperation& op : *ops) {
+    if (!op.has_data_offset())
+      continue;
+
+    CHECK(op.has_data_length());
+    vector<char> buf(op.data_length());
+    ssize_t rc = pread(in_fd, &buf[0], buf.size(), op.data_offset());
+    TEST_AND_RETURN_FALSE(rc == static_cast<ssize_t>(buf.size()));
+
+    // Add the hash of the data blobs for this operation
+    TEST_AND_RETURN_FALSE(DeltaDiffGenerator::AddOperationHash(&op, buf));
+
+    op.set_data_offset(*written);
+    TEST_AND_RETURN_FALSE(writer->Write(&buf[0], buf.size()));
+    *written += buf.size();
+  }
+
+  return true;
+}
+
 bool DeltaDiffGenerator::ReorderDataBlobs(
     DeltaArchiveManifest* manifest,
     const std::string& data_blobs_path,
@@ -1066,31 +1178,22 @@ bool DeltaDiffGenerator::ReorderDataBlobs(
   DirectFileWriter writer(new_data_blobs_path.c_str());
   TEST_AND_RETURN_FALSE_ERRNO(writer.Open() == 0);
   ScopedFileWriterCloser writer_closer(&writer);
-  uint64_t out_file_size = 0;
+  uint64_t written = 0;
 
-  for (int i = 0; i < (manifest->partition_operations_size() +
-                       manifest->noop_operations_size()); i++) {
-    InstallOperation* op = NULL;
-    if (i < manifest->partition_operations_size()) {
-      op = manifest->mutable_partition_operations(i);
-    } else {
-      op = manifest->mutable_noop_operations(
-          i - manifest->partition_operations_size());
-    }
-    if (!op->has_data_offset())
-      continue;
-    CHECK(op->has_data_length());
-    vector<char> buf(op->data_length());
-    ssize_t rc = pread(in_fd, &buf[0], buf.size(), op->data_offset());
-    TEST_AND_RETURN_FALSE(rc == static_cast<ssize_t>(buf.size()));
+  TEST_AND_RETURN_FALSE(ReorderProcedureDataBlobs(
+      manifest->mutable_partition_operations(),
+      in_fd,
+      &writer,
+      &written));
 
-    // Add the hash of the data blobs for this operation
-    TEST_AND_RETURN_FALSE(AddOperationHash(op, buf));
-
-    op->set_data_offset(out_file_size);
-    TEST_AND_RETURN_FALSE(writer.Write(&buf[0], buf.size()));
-    out_file_size += buf.size();
+  for (InstallProcedure& proc : *manifest->mutable_procedures()) {
+    TEST_AND_RETURN_FALSE(ReorderProcedureDataBlobs(
+        proc.mutable_operations(),
+        in_fd,
+        &writer,
+        &written));
   }
+
   return true;
 }
 
@@ -1201,6 +1304,8 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
     const string& old_image,
     const string& new_root,
     const string& new_image,
+    const string& old_kernel,
+    const string& new_kernel,
     const string& output_path,
     const string& private_key_path,
     uint64_t* metadata_size) {
@@ -1226,6 +1331,11 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
     }
   }
 
+  if (!new_kernel.empty()) {
+    // Sanity check kernel partition arg
+    TEST_AND_RETURN_FALSE(utils::FileSize(new_kernel) >= 0);
+  }
+
   vector<Block> blocks(new_image_size / kBlockSize);
   LOG(INFO) << "Invalid block index: " << Vertex::kInvalidIndex;
   LOG(INFO) << "Block count: " << blocks.size();
@@ -1242,6 +1352,8 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
   off_t data_file_size = 0;
 
   LOG(INFO) << "Reading files...";
+
+  vector<InstallOperation> kernel_ops;
 
   vector<Vertex::Index> final_order;
   {
@@ -1280,6 +1392,16 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
                                                 new_image,
                                                 &graph.back()));
 
+      if (!new_kernel.empty()) {
+        // Read kernel partition
+        TEST_AND_RETURN_FALSE(DeltaCompressKernel(old_kernel,
+                                                  new_kernel,
+                                                  &kernel_ops,
+                                                  fd,
+                                                  &data_file_size));
+        LOG(INFO) << "done reading kernel";
+      }
+
       CheckGraph(graph);
 
       LOG(INFO) << "Creating edges...";
@@ -1299,6 +1421,10 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
                                                 new_image_size,
                                                 &graph,
                                                 &final_order));
+
+      if (!new_kernel.empty())
+        TEST_AND_RETURN_FALSE(generator.Add(new_kernel, &kernel_ops));
+
       data_file_size = generator.Size();
     }
   }
@@ -1314,6 +1440,13 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
   CheckGraph(graph);
   manifest.set_block_size(kBlockSize);
 
+  if (!new_kernel.empty()) {
+    TEST_AND_RETURN_FALSE(KernelProcedureToManifest(old_kernel,
+                                                    new_kernel,
+                                                    kernel_ops,
+                                                    &manifest));
+  }
+
   // Reorder the data blobs with the newly ordered manifest
   string ordered_blobs_path;
   TEST_AND_RETURN_FALSE(utils::MakeTempFile(
@@ -1325,6 +1458,9 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
                                          temp_file_path,
                                          ordered_blobs_path));
   temp_file_unlinker.reset();
+
+  // Fill in the legacy noop_operations list.
+  ProceduresToNoops(&manifest);
 
   // Check that install op blobs are in order.
   uint64_t next_blob_offset = 0;

--- a/src/update_engine/delta_diff_generator.cc
+++ b/src/update_engine/delta_diff_generator.cc
@@ -1293,14 +1293,13 @@ bool DeltaDiffGenerator::GenerateDeltaUpdateFile(
                                               &data_file_size,
                                               &final_order));
     } else {
-      TEST_AND_RETURN_FALSE(FullUpdateGenerator::Run(&graph,
-                                                     new_image,
-                                                     new_image_size,
-                                                     fd,
-                                                     &data_file_size,
-                                                     kFullUpdateChunkSize,
-                                                     kBlockSize,
-                                                     &final_order));
+      FullUpdateGenerator generator(fd, kFullUpdateChunkSize, kBlockSize);
+
+      TEST_AND_RETURN_FALSE(generator.Partition(new_image,
+                                                new_image_size,
+                                                &graph,
+                                                &final_order));
+      data_file_size = generator.Size();
     }
   }
 

--- a/src/update_engine/delta_diff_generator.h
+++ b/src/update_engine/delta_diff_generator.h
@@ -57,6 +57,7 @@ class DeltaDiffGenerator {
   // This is the only function that external users of the class should call.
   // old_image and new_image are paths to two image files. They should be
   // mounted read-only at paths old_root and new_root respectively.
+  // {old,new}_kernel are paths to the old and new kernel images.
   // private_key_path points to a private key used to sign the update.
   // Pass empty string to not sign the update.
   // output_path is the filename where the delta update should be written.
@@ -66,6 +67,8 @@ class DeltaDiffGenerator {
                                       const std::string& old_image,
                                       const std::string& new_root,
                                       const std::string& new_image,
+                                      const std::string& old_kernel,
+                                      const std::string& new_kernel,
                                       const std::string& output_path,
                                       const std::string& private_key_path,
                                       uint64_t* metadata_size);
@@ -153,7 +156,8 @@ class DeltaDiffGenerator {
   // operations in the manifest. E.g. if manifest[0] has a data blob
   // "X" at offset 1, manifest[1] has a data blob "Y" at offset 0,
   // and data_blobs_path's file contains "YX", new_data_blobs_path
-  // will set to be a file that contains "XY".
+  // will set to be a file that contains "XY". The operations in
+  // are modified to refer to the new data blob locations.
   static bool ReorderDataBlobs(DeltaArchiveManifest* manifest,
                                const std::string& data_blobs_path,
                                const std::string& new_data_blobs_path);
@@ -207,8 +211,8 @@ class DeltaDiffGenerator {
   // (e.g., a move operation that copies blocks onto themselves).
   static bool IsNoopOperation(const InstallOperation& op);
 
-  static bool InitializePartitionInfo(const std::string& partition,
-                                      InstallInfo* info);
+  // Fill size and hash of the given device or file.
+  static bool InitializeInfo(const std::string& path, InstallInfo* info);
 
   // Runs the bsdiff tool on two files and returns the resulting delta in
   // |out|. Returns true on success.

--- a/src/update_engine/full_update_generator.cc
+++ b/src/update_engine/full_update_generator.cc
@@ -116,26 +116,6 @@ FullUpdateGenerator::FullUpdateGenerator(
   CHECK((chunk_size_ % block_size_) == 0);
 }
 
-bool FullUpdateGenerator::Run(
-    Graph* graph,
-    const std::string& new_image,
-    off_t image_size,
-    int fd,
-    off_t* data_file_size,
-    off_t chunk_size,
-    off_t block_size,
-    std::vector<Vertex::Index>* final_order) {
-  TEST_AND_RETURN_FALSE(chunk_size > 0);
-  TEST_AND_RETURN_FALSE((chunk_size % block_size) == 0);
-
-  FullUpdateGenerator generator(fd, chunk_size, block_size);
-  if (!generator.Partition(new_image, image_size, graph, final_order))
-    return false;
-
-  *data_file_size = generator.Size();
-  return true;
-}
-
 bool FullUpdateGenerator::Partition(const string& new_image,
                                     off_t image_size,
                                     Graph* graph,

--- a/src/update_engine/full_update_generator.h
+++ b/src/update_engine/full_update_generator.h
@@ -20,16 +20,6 @@ class FullUpdateGenerator {
   // operations, and writes relevant data to |fd|, updating |data_file_size| as
   // it does. Only the first |image_size| bytes are read from |new_image|
   // assuming that this is the actual file system.
-  static bool Run(
-      Graph* graph,
-      const std::string& new_image,
-      off_t image_size,
-      int fd,
-      off_t* data_file_size,
-      off_t chunk_size,
-      off_t block_size,
-      std::vector<Vertex::Index>* final_order);
-
   bool Partition(const std::string& new_image,
                  off_t image_size,
                  Graph* graph,

--- a/src/update_engine/full_update_generator.h
+++ b/src/update_engine/full_update_generator.h
@@ -13,6 +13,8 @@ namespace chromeos_update_engine {
 
 class FullUpdateGenerator {
  public:
+  FullUpdateGenerator(int fd, off_t chunk_size, off_t block_size);
+
   // Reads a new rootfs (|new_image|), creating a full update of chunk_size
   // chunks. Populates |graph| and |final_order| with data about the update
   // operations, and writes relevant data to |fd|, updating |data_file_size| as
@@ -28,8 +30,35 @@ class FullUpdateGenerator {
       off_t block_size,
       std::vector<Vertex::Index>* final_order);
 
+  bool Partition(const std::string& new_image,
+                 off_t image_size,
+                 Graph* graph,
+                 std::vector<Vertex::Index>* final_order);
+
+  // Reads a new file or device found at |path| and adds it to the update
+  // payload. Populates |ops| with the corresponding operations which must
+  // be added to the manifest. The optional parameter |size| may be used to
+  // limit the amount of data read from |path|.
+  bool Add(const std::string& path,
+           std::vector<InstallOperation>* ops);
+  bool Add(const std::string& path, off_t size,
+           std::vector<InstallOperation>* ops);
+
+  // Returns the size of the generated update payload.
+  off_t Size() { return data_file_size_; }
+
  private:
-  // This should never be constructed.
+  // Destination update payload to write to.
+  int fd_;
+
+  // Chunk size is the amount of data to give to each InstallOperation.
+  off_t chunk_size_;
+  // Basic unit use for data sizes/lengths in the manifest.
+  off_t block_size_;
+
+  // Amount of data written so far.
+  off_t data_file_size_;
+
   DISALLOW_IMPLICIT_CONSTRUCTORS(FullUpdateGenerator);
 };
 

--- a/src/update_engine/full_update_generator_unittest.cc
+++ b/src/update_engine/full_update_generator_unittest.cc
@@ -26,8 +26,10 @@ class FullUpdateGeneratorTest : public ::testing::Test { };
 
 TEST(FullUpdateGeneratorTest, RunTest) {
   vector<char> new_root(20 * 1024 * 1024);
+  vector<char> new_kern(16 * 1024 * 1024);
   const off_t kChunkSize = 128 * 1024;
   FillWithData(&new_root);
+  FillWithData(&new_kern);
   // Assume hashes take 2 MiB beyond the rootfs.
   off_t new_rootfs_size = new_root.size() - 2 * 1024 * 1024;
 
@@ -38,6 +40,13 @@ TEST(FullUpdateGeneratorTest, RunTest) {
   ScopedPathUnlinker new_root_path_unlinker(new_root_path);
   EXPECT_TRUE(WriteFileVector(new_root_path, new_root));
 
+  string new_kern_path;
+  EXPECT_TRUE(utils::MakeTempFile("/tmp/NewFullUpdateTest_K.XXXXXX",
+                                  &new_kern_path,
+                                  NULL));
+  ScopedPathUnlinker new_kern_path_unlinker(new_kern_path);
+  EXPECT_TRUE(WriteFileVector(new_kern_path, new_kern));
+
   string out_blobs_path;
   int out_blobs_fd;
   EXPECT_TRUE(utils::MakeTempFile("/tmp/NewFullUpdateTest_D.XXXXXX",
@@ -46,21 +55,22 @@ TEST(FullUpdateGeneratorTest, RunTest) {
   ScopedPathUnlinker out_blobs_path_unlinker(out_blobs_path);
   files::ScopedFD out_blobs_fd_closer(out_blobs_fd);
 
-  off_t out_blobs_length = 0;
-
   Graph graph;
+  vector<InstallOperation> kernel_ops;
   vector<Vertex::Index> final_order;
+  FullUpdateGenerator generator(out_blobs_fd, kChunkSize, kBlockSize);
 
-  EXPECT_TRUE(FullUpdateGenerator::Run(&graph,
-                                       new_root_path,
-                                       new_rootfs_size,
-                                       out_blobs_fd,
-                                       &out_blobs_length,
-                                       kChunkSize,
-                                       kBlockSize,
-                                       &final_order));
+  EXPECT_TRUE(generator.Partition(new_root_path,
+                                  new_rootfs_size,
+                                  &graph,
+                                  &final_order));
+  EXPECT_TRUE(generator.Add(new_kern_path, &kernel_ops));
+
   EXPECT_EQ(new_rootfs_size / kChunkSize, graph.size());
   EXPECT_EQ(new_rootfs_size / kChunkSize, final_order.size());
+  EXPECT_EQ(new_kern.size() / kChunkSize, kernel_ops.size());
+
+  off_t out_offset = 0;
   for (off_t i = 0; i < (new_rootfs_size / kChunkSize); ++i) {
     EXPECT_EQ(i, final_order[i]);
     EXPECT_EQ(1, graph[i].op.dst_extents_size());
@@ -73,7 +83,25 @@ TEST(FullUpdateGeneratorTest, RunTest) {
       EXPECT_EQ(InstallOperation_Type_REPLACE_BZ,
                 graph[i].op.type());
     }
+    EXPECT_EQ(out_offset, graph[i].op.data_offset());
+    out_offset += graph[i].op.data_length();
   }
+  for (size_t i = 0; i < kernel_ops.size(); ++i) {
+    EXPECT_EQ(1, kernel_ops[i].dst_extents_size());
+    EXPECT_EQ(i * kChunkSize / kBlockSize,
+              kernel_ops[i].dst_extents(0).start_block()) << "i = " << i;
+    EXPECT_EQ(kChunkSize / kBlockSize,
+              kernel_ops[i].dst_extents(0).num_blocks());
+    if (kernel_ops[i].type() !=
+        InstallOperation_Type_REPLACE) {
+      EXPECT_EQ(InstallOperation_Type_REPLACE_BZ,
+                kernel_ops[i].type());
+    }
+    EXPECT_EQ(out_offset, kernel_ops[i].data_offset());
+    out_offset += kernel_ops[i].data_length();
+  }
+  EXPECT_EQ(out_offset, generator.Size());
+  EXPECT_EQ(out_offset, utils::FileSize(out_blobs_path));
 }
 
 }  // namespace chromeos_update_engine

--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -36,6 +36,8 @@ DEFINE_string(new_dir, "",
               "Directory where the new partition is loop mounted read-only");
 DEFINE_string(old_image, "", "Path to the old partition");
 DEFINE_string(new_image, "", "Path to the new partition");
+DEFINE_string(old_kernel, "", "Path to the old kernel image");
+DEFINE_string(new_kernel, "", "Path to the new kernel image");
 DEFINE_string(in_file, "",
               "Path to input delta payload file used to hash/sign payloads "
               "and apply delta over old_image (for debugging)");
@@ -180,11 +182,11 @@ void ApplyDelta() {
   // Get original checksums
   LOG(INFO) << "Calculating original checksums";
   InstallInfo root_info;
-  CHECK(DeltaDiffGenerator::InitializePartitionInfo(FLAGS_old_image,
-                                                    &root_info));
+  CHECK(DeltaDiffGenerator::InitializeInfo(FLAGS_old_image, &root_info));
   install_plan.rootfs_hash.assign(root_info.hash().begin(),
                                   root_info.hash().end());
   install_plan.install_path = FLAGS_old_image;
+  install_plan.kernel_path = FLAGS_old_kernel;
   PayloadProcessor performer(&prefs, &install_plan);
   CHECK_EQ(performer.Open(), 0);
   vector<char> buf(1024 * 1024);
@@ -256,6 +258,8 @@ int Main(int argc, char** argv) {
                                                    FLAGS_old_image,
                                                    FLAGS_new_dir,
                                                    FLAGS_new_image,
+                                                   FLAGS_old_kernel,
+                                                   FLAGS_new_kernel,
                                                    FLAGS_out_file,
                                                    FLAGS_private_key,
                                                    &metadata_size)) {


### PR DESCRIPTION
Adds support for creating payloads that include kernels outside of the main filesystem. update_engine cannot yet install those kernels but but at the very least the payload_processor unit test has been updated to ensure the unsupported kernel is gracefully skipped.

Depends on https://github.com/coreos/update_engine/pull/113 and https://github.com/coreos/update_engine/pull/115