### PR TITLE
Add support for updating kernels

### DIFF
--- a/src/update_engine/delta_performer.cc
+++ b/src/update_engine/delta_performer.cc
@@ -83,9 +83,16 @@ int DeltaPerformer::Open() {
 
 int DeltaPerformer::Close() {
   int err = 0;
+  if (file_size_ >= 0) {
+    if (ftruncate(fd_, file_size_) == -1) {
+      err = errno;
+      PLOG(ERROR) << "Failed to truncate " << path_ << " to " << file_size_;
+    }
+  }
   if (close(fd_) == -1) {
-    err = errno;
-    PLOG(ERROR) << "Unable to close partition fd: " << fd_;
+    if (err == 0)
+      err = errno;
+    PLOG(ERROR) << "Failed to close " << path_;
   }
   fd_ = -2;  // Set to invalid so that calls to Open() will fail.
   return -err;

--- a/src/update_engine/delta_performer.h
+++ b/src/update_engine/delta_performer.h
@@ -30,7 +30,8 @@ class DeltaPerformer {
       : prefs_(prefs),
         path_(install_path),
         fd_(-1),
-        block_size_(0) {}
+        block_size_(0),
+        file_size_(-1) {}
 
   // Once Close()d, a DeltaPerformer can't be Open()ed again.
   int Open();
@@ -45,6 +46,11 @@ class DeltaPerformer {
   // Set block size specified by the manifest.
   void SetBlockSize(uint32_t size) {
     block_size_ = size;
+  }
+
+  // Set the size of the output file (leave unset for block devices).
+  void SetFileSize(off_t size) {
+    file_size_ = size;
   }
 
  private:
@@ -94,6 +100,9 @@ class DeltaPerformer {
 
   // The block size (parsed from the manifest).
   uint32_t block_size_;
+
+  // The final file size defined by the manifest.
+  off_t file_size_;
 
   DISALLOW_COPY_AND_ASSIGN(DeltaPerformer);
 };

--- a/src/update_engine/install_plan.cc
+++ b/src/update_engine/install_plan.cc
@@ -23,11 +23,13 @@ InstallPlan::InstallPlan(bool is_resume,
       payload_hash(payload_hash),
       partition_path(partition_path),
       kernel_path(utils::BootKernelName(partition_path)),
-      new_partition_size(0) {}
+      new_partition_size(0),
+      new_kernel_size(0) {}
 
 InstallPlan::InstallPlan() : is_resume(false),
                              payload_size(0),
-                             new_partition_size(0) {}
+                             new_partition_size(0),
+                             new_kernel_size(0) {}
 
 
 bool InstallPlan::operator==(const InstallPlan& that) const {

--- a/src/update_engine/install_plan.h
+++ b/src/update_engine/install_plan.h
@@ -40,6 +40,7 @@ struct InstallPlan {
   // hash is computed by FilesystemCopierAction(verify_hash=false) and
   // later validated by PayloadProcessor once it receives the manifest.
   std::vector<char> old_partition_hash;
+  std::vector<char> old_kernel_hash;
 
   // For verifying the update applied successfully. Values filled in by
   // PayloadProcessor once the update payload has been verified.
@@ -47,6 +48,8 @@ struct InstallPlan {
   // partition size and hash.
   uint64_t new_partition_size;
   std::vector<char> new_partition_hash;
+  uint64_t new_kernel_size;
+  std::vector<char> new_kernel_hash;
 };
 
 }  // namespace chromeos_update_engine

--- a/src/update_engine/payload_processor.h
+++ b/src/update_engine/payload_processor.h
@@ -103,8 +103,15 @@ class PayloadProcessor : public FileWriter {
   // update. Returns false otherwise.
   bool PrimeUpdateState();
 
+  // Fills in new partition/kernel size/hash in install_plan_ from the manifest.
+  bool SetNewPartitionInfo();
+  bool SetNewKernelInfo();
+
   // Writer for the main partition to be updated.
   DeltaPerformer partition_performer_;
+
+  // Writer for the boot kernel in the EFI System partition.
+  DeltaPerformer kernel_performer_;
 
   // Update Engine preference store.
   PrefsInterface* prefs_;


### PR DESCRIPTION
This is just enough to get update_engine to write out kernels included in the payload. A few more pieces are still needed:
 - copy the current running kernel prior to update (required for applying deltas)
 - verify the kernel after update has been applied
 - inform the postinst script that it does not need to copy the kernel itself