### PR TITLE
Enable kernel verification

### DIFF
--- a/src/update_engine/kernel_verifier_action.cc
+++ b/src/update_engine/kernel_verifier_action.cc
@@ -24,6 +24,15 @@ void KernelVerifierAction::PerformAction() {
   }
   install_plan_ = GetInputObject();
 
+  // If unset then a new kernel was never installed.
+  if (install_plan_.new_kernel_size == 0 &&
+      install_plan_.new_kernel_hash.empty()) {
+    if (HasOutputPipe())
+      SetOutputObject(install_plan_);
+    abort_action_completer.set_code(kActionCodeSuccess);
+    return;
+  }
+
   off_t length = utils::FileSize(install_plan_.kernel_path);
   if (length < 0) {
     LOG(ERROR) << "Failed to determine size of kernel "
@@ -61,6 +70,9 @@ void KernelVerifierAction::PerformAction() {
                << "\nExpected: " << expected_hash;
     return;
   }
+
+  LOG(INFO) << "Kernel size: " << length;
+  LOG(INFO) << "Kernel hash: " << hasher.hash();
 
   // Success! Pass along the new install_plan to the next action.
   if (HasOutputPipe())

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -382,7 +382,9 @@ bool PayloadProcessor::SetNewKernelInfo() {
     return true;
   }
 
-  return false;
+  // Allow payloads without kernels, the verify action will be skipped
+  // if the kernel size and hash are unset.
+  return true;
 }
 
 namespace {

--- a/src/update_engine/payload_processor.h
+++ b/src/update_engine/payload_processor.h
@@ -80,11 +80,11 @@ class PayloadProcessor : public FileWriter {
   // Execute a single operation. Result may be kActionCodeDownloadIncomplete.
   ActionExitCode PerformOperation();
 
-  // Verifies that the expected source partition hash (if present) match the
-  // hash for the current partition. Returns true if there're no expected
+  // Verifies that the expected source hashes (if present) match the hash
+  // for the current partition/files. Returns true if there're no expected
   // hash in the payload (e.g., if it's a new-style full update) or if the
   // hashes match; returns false otherwise.
-  bool VerifySourcePartition();
+  bool VerifySource();
 
   // Returns true if the payload signature message has been extracted from
   // payload, false otherwise.

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -21,6 +21,8 @@
 #include "update_engine/dbus_service.h"
 #include "update_engine/download_action.h"
 #include "update_engine/filesystem_copier_action.h"
+#include "update_engine/kernel_copier_action.h"
+#include "update_engine/kernel_verifier_action.h"
 #include "update_engine/libcurl_http_fetcher.h"
 #include "update_engine/multi_range_http_fetcher.h"
 #include "update_engine/omaha_request_action.h"
@@ -177,6 +179,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
       new OmahaResponseHandlerAction(system_state_));
   shared_ptr<FilesystemCopierAction> filesystem_copier_action(
       new FilesystemCopierAction(false));
+  shared_ptr<KernelCopierAction> kernel_copier_action(new KernelCopierAction);
   shared_ptr<OmahaRequestAction> download_started_action(
       new OmahaRequestAction(system_state_,
                              new OmahaEvent(
@@ -197,6 +200,8 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
                              false));
   shared_ptr<FilesystemCopierAction> filesystem_verifier_action(
       new FilesystemCopierAction(true));
+  shared_ptr<KernelVerifierAction> kernel_verifier_action(
+      new KernelVerifierAction);
   shared_ptr<PostinstallRunnerAction> postinstall_runner_action(
       new PostinstallRunnerAction);
   shared_ptr<OmahaRequestAction> update_complete_action(
@@ -212,10 +217,12 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   actions_.push_back(shared_ptr<AbstractAction>(update_check_action));
   actions_.push_back(shared_ptr<AbstractAction>(response_handler_action));
   actions_.push_back(shared_ptr<AbstractAction>(filesystem_copier_action));
+  actions_.push_back(shared_ptr<AbstractAction>(kernel_copier_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_started_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_action));
   actions_.push_back(shared_ptr<AbstractAction>(download_finished_action));
   actions_.push_back(shared_ptr<AbstractAction>(filesystem_verifier_action));
+  actions_.push_back(shared_ptr<AbstractAction>(kernel_verifier_action));
   actions_.push_back(shared_ptr<AbstractAction>(postinstall_runner_action));
   actions_.push_back(shared_ptr<AbstractAction>(update_complete_action));
 
@@ -231,10 +238,14 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   BondActions(response_handler_action.get(),
               filesystem_copier_action.get());
   BondActions(filesystem_copier_action.get(),
+              kernel_copier_action.get());
+  BondActions(kernel_copier_action.get(),
               download_action.get());
   BondActions(download_action.get(),
               filesystem_verifier_action.get());
   BondActions(filesystem_verifier_action.get(),
+              kernel_verifier_action.get());
+  BondActions(kernel_verifier_action.get(),
               postinstall_runner_action.get());
 }
 

--- a/src/update_engine/update_attempter_unittest.cc
+++ b/src/update_engine/update_attempter_unittest.cc
@@ -10,6 +10,8 @@
 #include "update_engine/action_mock.h"
 #include "update_engine/action_processor_mock.h"
 #include "update_engine/filesystem_copier_action.h"
+#include "update_engine/kernel_copier_action.h"
+#include "update_engine/kernel_verifier_action.h"
 #include "update_engine/mock_dbus_interface.h"
 #include "update_engine/mock_http_fetcher.h"
 #include "update_engine/mock_payload_state.h"
@@ -305,10 +307,12 @@ const string kActionTypes[] = {
   OmahaRequestAction::StaticType(),
   OmahaResponseHandlerAction::StaticType(),
   FilesystemCopierAction::StaticType(),
+  KernelCopierAction::StaticType(),
   OmahaRequestAction::StaticType(),
   DownloadAction::StaticType(),
   OmahaRequestAction::StaticType(),
   FilesystemCopierAction::StaticType(),
+  KernelVerifierAction::StaticType(),
   PostinstallRunnerAction::StaticType(),
   OmahaRequestAction::StaticType()
 };
@@ -335,10 +339,13 @@ void UpdateAttempterTest::UpdateTestVerify() {
   for (size_t i = 0; i < arraysize(kActionTypes); ++i) {
     EXPECT_EQ(kActionTypes[i], attempter_.actions_[i]->Type());
   }
+  // Indexes in attempter_.actions_ align with the kActionTypes list.
+  // actions_ itself is initialized by a series of push_back operations
+  // in UpdateAttempter::BuildUpdateActions.
   EXPECT_EQ(attempter_.response_handler_action_.get(),
             attempter_.actions_[1].get());
   DownloadAction* download_action =
-      dynamic_cast<DownloadAction*>(attempter_.actions_[4].get());
+      dynamic_cast<DownloadAction*>(attempter_.actions_[5].get());
   ASSERT_TRUE(download_action != NULL);
   EXPECT_EQ(&attempter_, download_action->delegate());
   EXPECT_EQ(UPDATE_STATUS_CHECKING_FOR_UPDATE, attempter_.status());


### PR DESCRIPTION
This completes the kernel update code. Last piece will be to update the post-install script action so the script won't clobber the kernel update_engine already installed.