### PR TITLE
Skip kernel update on really old systems

### DIFF
--- a/src/update_engine/kernel_copier_action.cc
+++ b/src/update_engine/kernel_copier_action.cc
@@ -23,8 +23,8 @@ void KernelCopierAction::PerformAction() {
     return;
   }
   install_plan_ = GetInputObject();
-  if (install_plan_.is_resume) {
-    // Resuming download, no copy needed.
+  if (install_plan_.is_resume || install_plan_.kernel_path.empty()) {
+    // Resuming download or no kernel to install, no copy needed.
     if (HasOutputPipe())
       SetOutputObject(install_plan_);
     abort_action_completer.set_code(kActionCodeSuccess);


### PR DESCRIPTION
The bootloader configuration in CoreOS <= 522.x.x was SYSLINUX based and used different install paths. If update_engine is running on such a system it shouldn't install kernels to the modern location since that would be wasting space in a somewhat small partition.

The post install script can remain as-is to support these systems, update_engine can just ignore the kernel.