### PR TITLE
kernel_copier_action: tolerate missing source kernels

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -83,10 +83,8 @@ if grep -q cros_legacy /proc/cmdline; then
         cp -v "${INSTALL_MNT}/boot/syslinux/default.cfg.${SLOT}" \
             "${ESP_MNT}/syslinux/default.cfg"
     fi
-fi
-
-# Update kernel on systems >= 668.x.x if update_engine didn't do it.
-if [[ -z "${INSTALL_KERNEL}" && -f "${ESP_MNT}/coreos/vmlinuz-a" ]]; then
+elif [[ -z "${INSTALL_KERNEL}" ]]; then
+    # not a legacy system but update_engine didn't handle the kernel.
     # kernel names are in lower case, ${SLOT,,} converts the slot name
     cp -v "${INSTALL_MNT}/boot/vmlinuz" \
        "${ESP_MNT}/coreos/vmlinuz-${SLOT,,}"


### PR DESCRIPTION
Kernels being a plain old file could potentially get deleted somehow and
that seems like a reasonable situation to recover from, particularly
since full updates don't even need the old kernel anyway.

This does mean that a kernel will get created on a few systems that
don't actually need it. Systems created after 522.x.x but before 668.x.x
read the kernel directly from /usr. Not a great way to know the
difference so lets favor simplicity and ignore that case.

The postinst script has been updated to match.