### PR TITLE
utils: resume using the rootdev library to detect the boot device

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,11 @@ AC_CHECK_LIB([bz2], [BZ2_bzDecompressInit], [],
 AC_CHECK_HEADERS([bzlib.h], [],
                  [AC_MSG_ERROR([*** bzlib.h not found])])
 
+AC_CHECK_LIB([rootdev], [rootdev], [],
+             [AC_MSG_ERROR([*** librootdev not found])])
+AC_CHECK_HEADERS([rootdev/rootdev.h], [],
+                 [AC_MSG_ERROR([*** rootdev.h not found])])
+
 # Detect libgflags presence and namespace. (may be gflags or google)
 # autoconf's C++ mode is only enabled for this test because other
 # macros like AM_PATH_GLIB_2_0 assume the default C mode.

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -60,6 +60,7 @@ void OmahaResponseHandlerAction::PerformAction() {
 
   if (install_plan_.old_partition_path.empty())
     install_plan_.old_partition_path = utils::BootDevice();
+  TEST_AND_RETURN(!install_plan_.old_partition_path.empty());
 
   TEST_AND_RETURN(GetInstallDev(
       install_plan_.old_partition_path,


### PR DESCRIPTION
In order to support verity we need the smarts of rootdev to resolve the
underlying partition instead of the dm block device. As the name implies
the library's default entry point `rootdev` resolves "/" but it also
exposes the oddly named `rootdev_wrapper` that can handle other devices.

Previously rootdev was removed in commit 78e5c78ce4a805566d5a63614d0db5ab7656368d.