### PR TITLE
update_check_scheduler: remove check for removable boot devices

### DIFF
--- a/src/update_engine/update_check_scheduler.cc
+++ b/src/update_engine/update_check_scheduler.cc
@@ -38,10 +38,6 @@ void UpdateCheckScheduler::Run() {
     LOG(WARNING) << "Non-official build: periodic update checks disabled.";
     return;
   }
-  if (IsBootDeviceRemovable()) {
-    LOG(WARNING) << "Removable device boot: periodic update checks disabled.";
-    return;
-  }
   enabled_ = true;
 
   // Registers this scheduler with the update attempter so that scheduler can be
@@ -53,10 +49,6 @@ void UpdateCheckScheduler::Run() {
   // by ScheduleNextCheck, normally at |kTimeoutPeriodicInterval|-second
   // intervals.
   ScheduleCheck(kTimeoutInitialInterval, kTimeoutRegularFuzz);
-}
-
-bool UpdateCheckScheduler::IsBootDeviceRemovable() {
-  return utils::IsRemovableDevice(utils::RootDevice(utils::BootDevice()));
 }
 
 bool UpdateCheckScheduler::IsOfficialBuild() {

--- a/src/update_engine/update_check_scheduler.h
+++ b/src/update_engine/update_check_scheduler.h
@@ -65,7 +65,6 @@ class UpdateCheckScheduler {
   FRIEND_TEST(UpdateCheckSchedulerTest, ComputeNextIntervalAndFuzzPriorityTest);
   FRIEND_TEST(UpdateCheckSchedulerTest, ComputeNextIntervalAndFuzzTest);
   FRIEND_TEST(UpdateCheckSchedulerTest, GTimeoutAddSecondsTest);
-  FRIEND_TEST(UpdateCheckSchedulerTest, IsBootDeviceRemovableTest);
   FRIEND_TEST(UpdateCheckSchedulerTest, IsOfficialBuildTest);
   FRIEND_TEST(UpdateCheckSchedulerTest, RunBootDeviceRemovableTest);
   FRIEND_TEST(UpdateCheckSchedulerTest, RunNonOfficialBuildTest);
@@ -84,7 +83,6 @@ class UpdateCheckScheduler {
   virtual guint GTimeoutAddSeconds(guint interval, GSourceFunc function);
 
   // Wrappers for utils functions so that they can be mocked in tests.
-  virtual bool IsBootDeviceRemovable();
   virtual bool IsOfficialBuild();
 
   // Returns true if an update check can be scheduled. An update check should

--- a/src/update_engine/update_check_scheduler_unittest.cc
+++ b/src/update_engine/update_check_scheduler_unittest.cc
@@ -38,7 +38,6 @@ class UpdateCheckSchedulerUnderTest : public UpdateCheckScheduler {
         mock_system_state_(mock_system_state) {}
 
   MOCK_METHOD2(GTimeoutAddSeconds, guint(guint seconds, GSourceFunc function));
-  MOCK_METHOD0(IsBootDeviceRemovable, bool());
   MOCK_METHOD0(IsOfficialBuild, bool());
 
   MockSystemState* mock_system_state_;
@@ -163,27 +162,10 @@ TEST_F(UpdateCheckSchedulerTest, GTimeoutAddSecondsTest) {
   g_main_loop_unref(loop_);
 }
 
-TEST_F(UpdateCheckSchedulerTest, IsBootDeviceRemovableTest) {
-  // Invokes the actual utils wrapper method rather than the subclass mock.
-  EXPECT_FALSE(scheduler_.UpdateCheckScheduler::IsBootDeviceRemovable());
-}
-
 TEST_F(UpdateCheckSchedulerTest, IsOfficialBuildTest) {
   // Invokes the actual utils wrapper method rather than the subclass mock.
   EXPECT_TRUE(scheduler_.UpdateCheckScheduler::IsOfficialBuild());
 }
-
-TEST_F(UpdateCheckSchedulerTest, RunBootDeviceRemovableTest) {
-  scheduler_.enabled_ = true;
-  EXPECT_CALL(scheduler_, IsOfficialBuild()).Times(1).WillOnce(Return(true));
-  EXPECT_CALL(scheduler_, IsBootDeviceRemovable())
-      .Times(1)
-      .WillOnce(Return(true));
-  scheduler_.Run();
-  EXPECT_FALSE(scheduler_.enabled_);
-  EXPECT_EQ(NULL, attempter_.update_check_scheduler());
-}
-
 TEST_F(UpdateCheckSchedulerTest, RunNonOfficialBuildTest) {
   scheduler_.enabled_ = true;
   EXPECT_CALL(scheduler_, IsOfficialBuild()).Times(1).WillOnce(Return(false));
@@ -199,9 +181,6 @@ TEST_F(UpdateCheckSchedulerTest, RunTest) {
             &interval_min,
             &interval_max);
   EXPECT_CALL(scheduler_, IsOfficialBuild()).Times(1).WillOnce(Return(true));
-  EXPECT_CALL(scheduler_, IsBootDeviceRemovable())
-      .Times(1)
-      .WillOnce(Return(false));
   EXPECT_CALL(scheduler_,
               GTimeoutAddSeconds(AllOf(Ge(interval_min), Le(interval_max)),
                                  scheduler_.StaticCheck)).Times(1);

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -312,53 +312,6 @@ bool RecursiveUnlinkDir(const std::string& path) {
   return true;
 }
 
-string RootDevice(const string& partition_device) {
-  files::FilePath device_path(partition_device);
-  if (device_path.DirName().value() != "/dev") {
-    return "";
-  }
-  string::const_iterator it = --partition_device.end();
-  for (; it >= partition_device.begin(); --it) {
-    if (!isdigit(*it))
-      break;
-  }
-  // Some devices contain a p before the partitions. For example:
-  // /dev/mmc0p4 should be shortened to /dev/mmc0.
-  if (*it == 'p')
-    --it;
-  return string(partition_device.begin(), it + 1);
-}
-
-string PartitionNumber(const string& partition_device) {
-  CHECK(!partition_device.empty());
-  string::const_iterator it = --partition_device.end();
-  for (; it >= partition_device.begin(); --it) {
-    if (!isdigit(*it))
-      break;
-  }
-  return string(it + 1, partition_device.end());
-}
-
-string SysfsBlockDevice(const string& device) {
-  files::FilePath device_path(device);
-  if (device_path.DirName().value() != "/dev") {
-    return "";
-  }
-  return files::FilePath("/sys/block").Append(device_path.BaseName()).value();
-}
-
-bool IsRemovableDevice(const std::string& device) {
-  string sysfs_block = SysfsBlockDevice(device);
-  string removable;
-  if (sysfs_block.empty() ||
-      !files::ReadFileToString(files::FilePath(sysfs_block).Append("removable"),
-                               &removable)) {
-    return false;
-  }
-  removable = strings::TrimWhitespace(removable);
-  return removable == "1";
-}
-
 std::string ErrnoNumberAsString(int err) {
   char buf[100];
   buf[0] = '\0';

--- a/src/update_engine/utils.h
+++ b/src/update_engine/utils.h
@@ -114,25 +114,6 @@ bool MakeTempDirectory(const std::string& dirname_template,
 // This WILL cross filesystem boundaries.
 bool RecursiveUnlinkDir(const std::string& path);
 
-// Returns the root device for a partition. For example,
-// RootDevice("/dev/sda3") returns "/dev/sda". Returns an empty string
-// if the input device is not of the "/dev/xyz" form.
-std::string RootDevice(const std::string& partition_device);
-
-// Returns the partition number, as a string, of partition_device. For example,
-// PartitionNumber("/dev/sda3") returns "3".
-std::string PartitionNumber(const std::string& partition_device);
-
-// Returns the sysfs block device for a root block device. For
-// example, SysfsBlockDevice("/dev/sda") returns
-// "/sys/block/sda". Returns an empty string if the input device is
-// not of the "/dev/xyz" form.
-std::string SysfsBlockDevice(const std::string& device);
-
-// Returns true if the root |device| (e.g., "/dev/sdb") is known to be
-// removable, false otherwise.
-bool IsRemovableDevice(const std::string& device);
-
 // Synchronously mount or unmount a filesystem. Return true on success.
 // Mounts as ext3 with default options.
 bool MountFilesystem(const std::string& device, const std::string& mountpoint,

--- a/src/update_engine/utils_unittest.cc
+++ b/src/update_engine/utils_unittest.cc
@@ -152,33 +152,6 @@ TEST(UtilsTest, TempFilenameTest) {
   EXPECT_FALSE(utils::StringHasSuffix(result, "XXXXXX"));
 }
 
-TEST(UtilsTest, RootDeviceTest) {
-  EXPECT_EQ("/dev/sda", utils::RootDevice("/dev/sda3"));
-  EXPECT_EQ("/dev/mmc0", utils::RootDevice("/dev/mmc0p3"));
-  EXPECT_EQ("", utils::RootDevice("/dev/foo/bar"));
-  EXPECT_EQ("", utils::RootDevice("/"));
-  EXPECT_EQ("", utils::RootDevice(""));
-}
-
-TEST(UtilsTest, SysfsBlockDeviceTest) {
-  EXPECT_EQ("/sys/block/sda", utils::SysfsBlockDevice("/dev/sda"));
-  EXPECT_EQ("", utils::SysfsBlockDevice("/foo/sda"));
-  EXPECT_EQ("", utils::SysfsBlockDevice("/dev/foo/bar"));
-  EXPECT_EQ("", utils::SysfsBlockDevice("/"));
-  EXPECT_EQ("", utils::SysfsBlockDevice("./"));
-  EXPECT_EQ("", utils::SysfsBlockDevice(""));
-}
-
-TEST(UtilsTest, IsRemovableDeviceTest) {
-  EXPECT_FALSE(utils::IsRemovableDevice(""));
-  EXPECT_FALSE(utils::IsRemovableDevice("/dev/non-existent-device"));
-}
-
-TEST(UtilsTest, PartitionNumberTest) {
-  EXPECT_EQ("3", utils::PartitionNumber("/dev/sda3"));
-  EXPECT_EQ("3", utils::PartitionNumber("/dev/mmc0p3"));
-}
-
 TEST(UtilsTest, FuzzIntTest) {
   static const unsigned int kRanges[] = { 0, 1, 2, 20 };
   for (size_t r = 0; r < arraysize(kRanges); ++r) {


### PR DESCRIPTION
This is not applicable to CoreOS like it would have been ChromeOS and
breaks perfectly legitimate installs.

Fixes https://github.com/coreos/bugs/issues/1587