### PR TITLE
Add support for handling PCR policy data

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -108,6 +108,7 @@ libupdate_engine_a_SOURCES = \
 	src/update_engine/payload_processor.cc \
 	src/update_engine/payload_signer.cc \
 	src/update_engine/payload_state.cc \
+	src/update_engine/pcr_policy_post_action.cc \
 	src/update_engine/postinstall_runner_action.cc \
 	src/update_engine/prefs.cc \
 	src/update_engine/simple_key_value_store.cc \
@@ -162,6 +163,7 @@ update_engine_unittests_SOURCES = \
 	src/update_engine/payload_processor_unittest.cc \
 	src/update_engine/payload_signer_unittest.cc \
 	src/update_engine/payload_state_unittest.cc \
+	src/update_engine/pcr_policy_post_action_unittest.cc \
 	src/update_engine/postinstall_runner_action_unittest.cc \
 	src/update_engine/prefs_unittest.cc \
 	src/update_engine/simple_key_value_store_unittest.cc \

--- a/src/update_engine/action_processor.h
+++ b/src/update_engine/action_processor.h
@@ -66,6 +66,7 @@ enum ActionExitCode {
   kActionCodeOmahaUpdateDeferredForBackoff = 40,
   kActionCodePostinstallPowerwashError = 41,
   kActionCodeNewPCRPolicyVerificationError = 42,
+  kActionCodeNewPCRPolicyHTTPError = 43,
 
   // DownloadIncomplete isn't an error to report, it is analogous to EAGAIN
   // and for internal use to indicate that the processing must pause until

--- a/src/update_engine/action_processor.h
+++ b/src/update_engine/action_processor.h
@@ -65,6 +65,7 @@ enum ActionExitCode {
   kActionCodeDownloadMetadataSignatureMissingError = 39,
   kActionCodeOmahaUpdateDeferredForBackoff = 40,
   kActionCodePostinstallPowerwashError = 41,
+  kActionCodeNewPCRPolicyVerificationError = 42,
 
   // DownloadIncomplete isn't an error to report, it is analogous to EAGAIN
   // and for internal use to indicate that the processing must pause until

--- a/src/update_engine/delta_diff_generator.h
+++ b/src/update_engine/delta_diff_generator.h
@@ -69,6 +69,7 @@ class DeltaDiffGenerator {
                                       const std::string& new_image,
                                       const std::string& old_kernel,
                                       const std::string& new_kernel,
+                                      const std::string& pcr_policy,
                                       const std::string& output_path,
                                       const std::string& private_key_path,
                                       uint64_t* metadata_size);

--- a/src/update_engine/delta_performer.cc
+++ b/src/update_engine/delta_performer.cc
@@ -58,7 +58,7 @@ int DeltaPerformer::Open() {
     LOG(ERROR) << "Attempting to re-open " << path_;
     return -EINVAL;
   }
-  fd_ = open(path_.c_str(), O_RDWR, 000);
+  fd_ = open(path_.c_str(), O_RDWR | O_CREAT, 0600);
   if (fd_ < 0) {
     int err = errno;
     PLOG(ERROR) << "Unable to open file " << path_;

--- a/src/update_engine/generate_delta_main.cc
+++ b/src/update_engine/generate_delta_main.cc
@@ -38,6 +38,7 @@ DEFINE_string(old_image, "", "Path to the old partition");
 DEFINE_string(new_image, "", "Path to the new partition");
 DEFINE_string(old_kernel, "", "Path to the old kernel image");
 DEFINE_string(new_kernel, "", "Path to the new kernel image");
+DEFINE_string(pcr_policy, "", "Path to the new PCR policy zip");
 DEFINE_string(in_file, "",
               "Path to input delta payload file used to hash/sign payloads "
               "and apply delta over old_image (for debugging)");
@@ -261,6 +262,7 @@ int Main(int argc, char** argv) {
                                                    FLAGS_new_image,
                                                    FLAGS_old_kernel,
                                                    FLAGS_new_kernel,
+                                                   FLAGS_pcr_policy,
                                                    FLAGS_out_file,
                                                    FLAGS_private_key,
                                                    &metadata_size)) {

--- a/src/update_engine/http_common.cc
+++ b/src/update_engine/http_common.cc
@@ -58,6 +58,7 @@ const char *GetHttpContentTypeString(HttpContentType type) {
     const char* str;
   } http_content_type_table[] = {
     { kHttpContentTypeTextXml, "text/xml" },
+    { kHttpContentTypeOctetStream, "application/octet-stream" },
   };
 
   bool is_found = false;

--- a/src/update_engine/http_common.h
+++ b/src/update_engine/http_common.h
@@ -50,6 +50,7 @@ HttpResponseCode StringToHttpResponseCode(const char *s);
 enum HttpContentType {
   kHttpContentTypeUnspecified = 0,
   kHttpContentTypeTextXml,
+  kHttpContentTypeOctetStream,
 };
 
 // Returns a standard HTTP Content-Type string.

--- a/src/update_engine/install_plan.cc
+++ b/src/update_engine/install_plan.cc
@@ -23,12 +23,14 @@ InstallPlan::InstallPlan(bool is_resume,
       payload_hash(payload_hash),
       partition_path(partition_path),
       new_partition_size(0),
-      new_kernel_size(0) {}
+      new_kernel_size(0),
+      new_pcr_policy_size(0) {}
 
 InstallPlan::InstallPlan() : is_resume(false),
                              payload_size(0),
                              new_partition_size(0),
-                             new_kernel_size(0) {}
+                             new_kernel_size(0),
+                             new_pcr_policy_size(0) {}
 
 
 bool InstallPlan::operator==(const InstallPlan& that) const {
@@ -38,6 +40,7 @@ bool InstallPlan::operator==(const InstallPlan& that) const {
           (payload_hash == that.payload_hash) &&
           (partition_path == that.partition_path) &&
           (kernel_path == that.kernel_path) &&
+          (pcr_policy_path == that.pcr_policy_path) &&
           (old_partition_path == that.old_partition_path) &&
           (old_kernel_path == that.old_kernel_path));
 }
@@ -54,6 +57,7 @@ void InstallPlan::Dump() const {
             << ", payload hash: " << payload_hash
             << ", partition_path: " << partition_path
             << ", kernel_path: " << kernel_path
+            << ", pcr_policy_path: " << pcr_policy_path
             << ", old_partition_path: " << old_partition_path
             << ", old_kernel_path: " << old_kernel_path;
 }

--- a/src/update_engine/install_plan.h
+++ b/src/update_engine/install_plan.h
@@ -35,6 +35,7 @@ struct InstallPlan {
   std::string payload_hash;              // SHA256 hash of the payload
   std::string partition_path;            // path to main partition device
   std::string kernel_path;               // path to kernel image
+  std::string pcr_policy_path;           // path to pcr policy zip file
 
   // Location to copy currently running system from.
   std::string old_partition_path;
@@ -54,6 +55,8 @@ struct InstallPlan {
   std::vector<char> new_partition_hash;
   uint64_t new_kernel_size;
   std::vector<char> new_kernel_hash;
+  uint64_t new_pcr_policy_size;
+  std::vector<char> new_pcr_policy_hash;
 
   // Optional arguments to pass to the post install script. Used to inform
   // the script about optional update procedures that ran. For example

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -52,6 +52,7 @@ bool OmahaRequestParams::Init(bool interactive) {
   bootid_ = utils::GetBootId();
   machineid_ = utils::GetMachineId();
   update_url_ = GetConfValue("SERVER", kProductionOmahaUrl);
+  pcr_policy_url_ = GetConfValue("PCR_POLICY_SERVER", "");
   interactive_ = interactive;
 
   app_channel_ = GetConfValue("GROUP", kDefaultChannel);

--- a/src/update_engine/omaha_request_params.h
+++ b/src/update_engine/omaha_request_params.h
@@ -98,6 +98,9 @@ class OmahaRequestParams {
   inline void set_update_url(const std::string& url) { update_url_ = url; }
   inline std::string update_url() const { return update_url_; }
 
+  inline void set_pcr_policy_url(const std::string& url) { pcr_policy_url_ = url; }
+  inline std::string pcr_policy_url() const { return pcr_policy_url_; }
+
   // Suggested defaults
   static const char* const kAppId;
   static const char* const kOsPlatform;
@@ -154,6 +157,9 @@ class OmahaRequestParams {
 
   // The URL to send the Omaha request to.
   std::string update_url_;
+
+  // The URL to send PCR policy data to.
+  std::string pcr_policy_url_;
 
   // When reading files, prepend root_ to the paths. Useful for testing.
   std::string root_;

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -74,6 +74,10 @@ void OmahaResponseHandlerAction::PerformAction() {
       install_plan_.partition_path,
       &install_plan_.kernel_path));
 
+  TEST_AND_RETURN(GetPCRPolicyPath(
+      install_plan_.partition_path,
+      &install_plan_.pcr_policy_path));
+
   TEST_AND_RETURN(HasOutputPipe());
   if (HasOutputPipe())
     SetOutputObject(install_plan_);
@@ -135,6 +139,20 @@ bool OmahaResponseHandlerAction::GetKernelPath(const std::string& part_path,
   }
   if (last_char == '4') {
     *kernel_path = "/boot/coreos/vmlinuz-b";
+    return true;
+  }
+  return false;
+}
+
+bool OmahaResponseHandlerAction::GetPCRPolicyPath(const std::string& part_path,
+                                                  std::string* policy_path) {
+  char last_char = part_path[part_path.size() - 1];
+  if (last_char == '3') {
+    *policy_path = "/var/lib/update_engine/pcrs-a.zip";
+    return true;
+  }
+  if (last_char == '4') {
+    *policy_path = "/var/lib/update_engine/pcrs-b.zip";
     return true;
   }
   return false;

--- a/src/update_engine/omaha_response_handler_action.h
+++ b/src/update_engine/omaha_response_handler_action.h
@@ -70,6 +70,10 @@ class OmahaResponseHandlerAction : public Action<OmahaResponseHandlerAction> {
   static bool GetKernelPath(const std::string& part_path,
                             std::string* kernel_path);
 
+  // Select the pcr policy path associated with the given partition.
+  static bool GetPCRPolicyPath(const std::string& part_path,
+                               std::string* policy_path);
+
   // Global system context.
   SystemState* system_state_;
 

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -297,14 +297,6 @@ bool PayloadProcessor::ExtractSignatureMessage(const vector<char>& data) {
   return true;
 }
 
-#define TEST_AND_RETURN_VAL(_retval, _condition)                \
-  do {                                                          \
-    if (!(_condition)) {                                        \
-      LOG(ERROR) << "VerifyPayload failure: " << #_condition;   \
-      return _retval;                                           \
-    }                                                           \
-  } while (0);
-
 ActionExitCode PayloadProcessor::VerifyPayload() {
   LOG(INFO) << "Verifying delta payload using public key: " << public_key_path_;
 

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -55,6 +55,7 @@ void LogPartitionInfo(const DeltaArchiveManifest& manifest) {
 PayloadProcessor::PayloadProcessor(PrefsInterface* prefs, InstallPlan* install_plan)
   : partition_performer_(prefs, install_plan->partition_path),
     kernel_performer_(prefs, install_plan->kernel_path),
+    pcr_policy_performer_(prefs, install_plan->pcr_policy_path),
     prefs_(prefs),
     install_plan_(install_plan),
     manifest_valid_(false),
@@ -77,6 +78,14 @@ int PayloadProcessor::Open() {
       return err;
     }
   }
+  if (!install_plan_->pcr_policy_path.empty()) {
+    err = pcr_policy_performer_.Open();
+    if (err != 0) {
+      kernel_performer_.Close();
+      partition_performer_.Close();
+      return err;
+    }
+  }
   return 0;
 }
 
@@ -84,6 +93,12 @@ int PayloadProcessor::Close() {
   int err = partition_performer_.Close();
   if (!install_plan_->kernel_path.empty()) {
     int err2 = kernel_performer_.Close();
+    if (err == 0) {
+      err = err2;
+    }
+  }
+  if (!install_plan_->pcr_policy_path.empty()) {
+    int err2 = pcr_policy_performer_.Close();
     if (err == 0) {
       err = err2;
     }
@@ -181,17 +196,28 @@ ActionExitCode PayloadProcessor::LoadManifest() {
   }
 
   kernel_performer_.SetBlockSize(manifest_.block_size());
+  pcr_policy_performer_.SetBlockSize(manifest_.block_size());
   for (const InstallProcedure &proc : manifest_.procedures()) {
-    // KERNELs are plain files so we must specify their final size.
-    if (proc.has_type() &&
-        proc.type() == InstallProcedure_Type_KERNEL &&
-        proc.has_new_info() &&
-        !install_plan_->kernel_path.empty()) {
-      kernel_performer_.SetFileSize(proc.new_info().size());
-    }
-
     for (const InstallOperation &op : proc.operations()) {
       operations_.emplace_back(&proc, &op);
+    }
+
+    if (!proc.has_type())
+      continue;
+
+    // Any procedures for plain files must provide final file size.
+    TEST_AND_RETURN_VAL(kActionCodeDownloadManifestParseError,
+                        proc.has_new_info());
+
+    switch (proc.type()) {
+      case InstallProcedure_Type_KERNEL:
+        if (!install_plan_->kernel_path.empty())
+          kernel_performer_.SetFileSize(proc.new_info().size());
+        break;
+      case InstallProcedure_Type_PCR_POLICY:
+        if (!install_plan_->pcr_policy_path.empty())
+          pcr_policy_performer_.SetFileSize(proc.new_info().size());
+        break;
     }
   }
 
@@ -221,7 +247,7 @@ ActionExitCode PayloadProcessor::PerformOperation() {
         break;
       case InstallProcedure_Type_PCR_POLICY:
         if (!install_plan_->pcr_policy_path.empty())
-          performer = nullptr;  // TODO
+          performer = &pcr_policy_performer_;
         break;
     }
   }
@@ -314,9 +340,7 @@ ActionExitCode PayloadProcessor::VerifyPayload() {
 
   // Update the InstallPlan so the update can be verified.
   TEST_AND_RETURN_VAL(kActionCodeDownloadPayloadVerificationError,
-                      SetNewPartitionInfo());
-  TEST_AND_RETURN_VAL(kActionCodeDownloadPayloadVerificationError,
-                      SetNewKernelInfo());
+                      SetNewInfo());
 
   // Verifies the signed payload hash.
   if (!utils::FileExists(public_key_path_.c_str())) {
@@ -352,36 +376,47 @@ ActionExitCode PayloadProcessor::VerifyPayload() {
   return kActionCodeSuccess;
 }
 
-bool PayloadProcessor::SetNewPartitionInfo() {
+bool PayloadProcessor::SetNewInfo() {
   TEST_AND_RETURN_FALSE(manifest_valid_ &&
                         manifest_.has_new_partition_info());
   install_plan_->new_partition_size = manifest_.new_partition_info().size();
   install_plan_->new_partition_hash.assign(
       manifest_.new_partition_info().hash().begin(),
       manifest_.new_partition_info().hash().end());
-  return true;
-}
-
-bool PayloadProcessor::SetNewKernelInfo() {
-  if (install_plan_->kernel_path.empty())
-    return true;
 
   for (const InstallProcedure& proc : manifest_.procedures()) {
-    if (!proc.has_type() || proc.type() != InstallProcedure_Type_KERNEL)
+    if (!proc.has_type())
       continue;
 
-    TEST_AND_RETURN_FALSE(proc.has_new_info());
-    install_plan_->new_kernel_size = proc.new_info().size();
-    install_plan_->new_kernel_hash.assign(
-        proc.new_info().hash().begin(),
-        proc.new_info().hash().end());
-    install_plan_->postinst_args.push_back(
-        "KERNEL=" + install_plan_->kernel_path);
-    return true;
+    switch (proc.type()) {
+      case InstallProcedure_Type_KERNEL:
+        if (install_plan_->kernel_path.empty())
+          continue;
+
+        TEST_AND_RETURN_FALSE(proc.has_new_info());
+        install_plan_->new_kernel_size = proc.new_info().size();
+        install_plan_->new_kernel_hash.assign(
+            proc.new_info().hash().begin(),
+            proc.new_info().hash().end());
+        install_plan_->postinst_args.push_back(
+            "KERNEL=" + install_plan_->kernel_path);
+        break;
+
+      case InstallProcedure_Type_PCR_POLICY:
+        if (install_plan_->pcr_policy_path.empty())
+          continue;
+
+        TEST_AND_RETURN_FALSE(proc.has_new_info());
+        install_plan_->new_pcr_policy_size = proc.new_info().size();
+        install_plan_->new_pcr_policy_hash.assign(
+            proc.new_info().hash().begin(),
+            proc.new_info().hash().end());
+        install_plan_->postinst_args.push_back(
+            "PCR_POLICY=" + install_plan_->pcr_policy_path);
+        break;
+    }
   }
 
-  // Allow payloads without kernels, the verify action will be skipped
-  // if the kernel size and hash are unset.
   return true;
 }
 

--- a/src/update_engine/payload_processor.cc
+++ b/src/update_engine/payload_processor.cc
@@ -219,6 +219,10 @@ ActionExitCode PayloadProcessor::PerformOperation() {
         if (!install_plan_->kernel_path.empty())
           performer = &kernel_performer_;
         break;
+      case InstallProcedure_Type_PCR_POLICY:
+        if (!install_plan_->pcr_policy_path.empty())
+          performer = nullptr;  // TODO
+        break;
     }
   }
 

--- a/src/update_engine/payload_processor.h
+++ b/src/update_engine/payload_processor.h
@@ -103,15 +103,17 @@ class PayloadProcessor : public FileWriter {
   // update. Returns false otherwise.
   bool PrimeUpdateState();
 
-  // Fills in new partition/kernel size/hash in install_plan_ from the manifest.
-  bool SetNewPartitionInfo();
-  bool SetNewKernelInfo();
+  // Fills in new partition/file size/hash in install_plan_ from the manifest.
+  bool SetNewInfo();
 
   // Writer for the main partition to be updated.
   DeltaPerformer partition_performer_;
 
   // Writer for the boot kernel in the EFI System partition.
   DeltaPerformer kernel_performer_;
+
+  // Writer for the pcr policy zip file.
+  DeltaPerformer pcr_policy_performer_;
 
   // Update Engine preference store.
   PrefsInterface* prefs_;

--- a/src/update_engine/payload_processor_unittest.cc
+++ b/src/update_engine/payload_processor_unittest.cc
@@ -365,6 +365,7 @@ static void GenerateDeltaFile(DeltaState *state) {
             state->b_img,
             full_update ? "" : state->a_kernel,
             state->b_kernel,
+            "",  // pcr_policy
             state->delta_path,
             private_key,
             &state->metadata_size));

--- a/src/update_engine/payload_state.cc
+++ b/src/update_engine/payload_state.cc
@@ -172,6 +172,7 @@ void PayloadState::UpdateFailed(ActionExitCode error) {
     case kActionCodeOmahaUpdateDeferredPerPolicy:
     case kActionCodeOmahaUpdateDeferredForBackoff:
     case kActionCodePostinstallPowerwashError:
+    case kActionCodeNewPCRPolicyVerificationError:
       LOG(INFO) << "Not incrementing URL index or failure count for this error";
       break;
 

--- a/src/update_engine/payload_state.cc
+++ b/src/update_engine/payload_state.cc
@@ -173,6 +173,7 @@ void PayloadState::UpdateFailed(ActionExitCode error) {
     case kActionCodeOmahaUpdateDeferredForBackoff:
     case kActionCodePostinstallPowerwashError:
     case kActionCodeNewPCRPolicyVerificationError:
+    case kActionCodeNewPCRPolicyHTTPError:
       LOG(INFO) << "Not incrementing URL index or failure count for this error";
       break;
 

--- a/src/update_engine/pcr_policy_post_action.cc
+++ b/src/update_engine/pcr_policy_post_action.cc
@@ -1,0 +1,91 @@
+// Copyright (c) 2016 The CoreOS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "update_engine/pcr_policy_post_action.h"
+
+#include <string>
+#include <vector>
+
+#include "update_engine/utils.h"
+#include "update_engine/omaha_hash_calculator.h"
+
+using std::string;
+using std::vector;
+
+namespace chromeos_update_engine {
+
+void PCRPolicyPostAction::PerformAction() {
+  // Will tell the ActionProcessor we've failed if we return.
+  ScopedActionCompleter abort_action_completer(processor_, this);
+  abort_action_completer.set_code(kActionCodeNewPCRPolicyVerificationError);
+
+  if (!HasInputObject()) {
+    LOG(ERROR) << "PCRPolicyPostAction missing input object.";
+    return;
+  }
+  install_plan_ = GetInputObject();
+
+  // If unset then a new pcr_policy was never installed.
+  if (install_plan_.new_pcr_policy_size == 0 &&
+      install_plan_.new_pcr_policy_hash.empty()) {
+    if (HasOutputPipe())
+      SetOutputObject(install_plan_);
+    abort_action_completer.set_code(kActionCodeSuccess);
+    return;
+  }
+
+  off_t length = utils::FileSize(install_plan_.pcr_policy_path);
+  if (length < 0) {
+    LOG(ERROR) << "Failed to determine size of "
+               << install_plan_.pcr_policy_path;
+    return;
+  }
+
+  if (static_cast<uint64_t>(length) != install_plan_.new_pcr_policy_size) {
+    LOG(ERROR) << "PCR policy verification failure: "
+               << install_plan_.pcr_policy_path << " is "
+               << length << " bytes. Expected "
+               << install_plan_.new_pcr_policy_size;
+    return;
+  }
+
+  vector<char> data;
+  if (!utils::ReadFile(install_plan_.pcr_policy_path, &data)) {
+    LOG(ERROR) << "Failed to read " << install_plan_.pcr_policy_path;
+    return;
+  }
+
+  OmahaHashCalculator hasher;
+  if (!hasher.Update(data.data(), data.size()) || !hasher.Finalize()) {
+    LOG(ERROR) << "Failed to compute hash of "
+               << install_plan_.pcr_policy_path;
+    return;
+  }
+
+  if (hasher.raw_hash() != install_plan_.new_pcr_policy_hash) {
+    string expected_hash;
+    if (!OmahaHashCalculator::Base64Encode(
+          install_plan_.new_pcr_policy_hash.data(),
+          install_plan_.new_pcr_policy_hash.size(),
+          &expected_hash)) {
+      expected_hash = "<unknown>";
+    }
+    LOG(ERROR) << "PCR policy verification failure: "
+               << install_plan_.pcr_policy_path
+               << "\nBad hash: " << hasher.hash()
+               << "\nExpected: " << expected_hash;
+    return;
+  }
+
+  LOG(INFO) << "PCR policy size: " << length;
+  LOG(INFO) << "PCR policy hash: " << hasher.hash();
+
+  // Success! Pass along the new install_plan to the next action.
+  if (HasOutputPipe())
+    SetOutputObject(install_plan_);
+  abort_action_completer.set_code(kActionCodeSuccess);
+  return;
+}
+
+}  // namespace chromeos_update_engine

--- a/src/update_engine/pcr_policy_post_action.cc
+++ b/src/update_engine/pcr_policy_post_action.cc
@@ -81,7 +81,15 @@ void PCRPolicyPostAction::PerformAction() {
   LOG(INFO) << "PCR policy size: " << length;
   LOG(INFO) << "PCR policy hash: " << hasher.hash();
 
-  string url; // TODO
+  string url = system_state_->request_params()->pcr_policy_url();
+  if (url.empty()) {
+    LOG(INFO) << "PCR policy server disabled.";
+    if (HasOutputPipe())
+      SetOutputObject(install_plan_);
+    abort_action_completer.set_code(kActionCodeSuccess);
+    return;
+  }
+
   http_fetcher_->set_delegate(this);
   http_fetcher_->SetPostData(data.data(), data.size(),
                              kHttpContentTypeOctetStream);

--- a/src/update_engine/pcr_policy_post_action.h
+++ b/src/update_engine/pcr_policy_post_action.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 The CoreOS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROMEOS_PLATFORM_UPDATE_ENGINE_PCR_POLICY_POST_ACTION_H__
+#define CHROMEOS_PLATFORM_UPDATE_ENGINE_PCR_POLICY_POST_ACTION_H__
+
+#include <string>
+
+#include "update_engine/action.h"
+#include "update_engine/install_plan.h"
+
+namespace chromeos_update_engine {
+
+class PCRPolicyPostAction;
+
+template<>
+class ActionTraits<PCRPolicyPostAction> {
+ public:
+  // Takes the install plan as input
+  typedef InstallPlan InputObjectType;
+  // Passes the install plan as output
+  typedef InstallPlan OutputObjectType;
+};
+
+class PCRPolicyPostAction : public Action<PCRPolicyPostAction> {
+ public:
+  PCRPolicyPostAction() {}
+
+  typedef ActionTraits<PCRPolicyPostAction>::InputObjectType
+  InputObjectType;
+  typedef ActionTraits<PCRPolicyPostAction>::OutputObjectType
+  OutputObjectType;
+  void PerformAction();
+  void TerminateProcessing() {}
+
+  // Debugging/logging
+  static std::string StaticType() { return "PCRPolicyPostAction"; }
+  std::string Type() const { return StaticType(); }
+
+ private:
+  // The install plan we're passed in via the input pipe.
+  InstallPlan install_plan_;
+
+  DISALLOW_COPY_AND_ASSIGN(PCRPolicyPostAction);
+};
+
+}  // namespace chromeos_update_engine
+
+#endif  // CHROMEOS_PLATFORM_UPDATE_ENGINE_PCR_POLICY_POST_ACTION_H__

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -29,6 +29,7 @@
 #include "update_engine/omaha_request_params.h"
 #include "update_engine/omaha_response_handler_action.h"
 #include "update_engine/payload_state_interface.h"
+#include "update_engine/pcr_policy_post_action.h"
 #include "update_engine/postinstall_runner_action.h"
 #include "update_engine/prefs_interface.h"
 #include "update_engine/subprocess.h"
@@ -202,6 +203,8 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
       new FilesystemCopierAction(true));
   shared_ptr<KernelVerifierAction> kernel_verifier_action(
       new KernelVerifierAction);
+  shared_ptr<PCRPolicyPostAction> pcr_policy_post_action(
+      new PCRPolicyPostAction(system_state_, new LibcurlHttpFetcher()));
   shared_ptr<PostinstallRunnerAction> postinstall_runner_action(
       new PostinstallRunnerAction);
   shared_ptr<OmahaRequestAction> update_complete_action(
@@ -223,6 +226,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   actions_.push_back(shared_ptr<AbstractAction>(download_finished_action));
   actions_.push_back(shared_ptr<AbstractAction>(filesystem_verifier_action));
   actions_.push_back(shared_ptr<AbstractAction>(kernel_verifier_action));
+  actions_.push_back(shared_ptr<AbstractAction>(pcr_policy_post_action));
   actions_.push_back(shared_ptr<AbstractAction>(postinstall_runner_action));
   actions_.push_back(shared_ptr<AbstractAction>(update_complete_action));
 
@@ -246,6 +250,8 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
   BondActions(filesystem_verifier_action.get(),
               kernel_verifier_action.get());
   BondActions(kernel_verifier_action.get(),
+              pcr_policy_post_action.get());
+  BondActions(pcr_policy_post_action.get(),
               postinstall_runner_action.get());
 }
 

--- a/src/update_engine/update_attempter_unittest.cc
+++ b/src/update_engine/update_attempter_unittest.cc
@@ -16,6 +16,7 @@
 #include "update_engine/mock_http_fetcher.h"
 #include "update_engine/mock_payload_state.h"
 #include "update_engine/mock_system_state.h"
+#include "update_engine/pcr_policy_post_action.h"
 #include "update_engine/postinstall_runner_action.h"
 #include "update_engine/prefs.h"
 #include "update_engine/prefs_mock.h"
@@ -313,6 +314,7 @@ const string kActionTypes[] = {
   OmahaRequestAction::StaticType(),
   FilesystemCopierAction::StaticType(),
   KernelVerifierAction::StaticType(),
+  PCRPolicyPostAction::StaticType(),
   PostinstallRunnerAction::StaticType(),
   OmahaRequestAction::StaticType()
 };

--- a/src/update_engine/update_metadata.proto
+++ b/src/update_engine/update_metadata.proto
@@ -20,8 +20,8 @@ package chromeos_update_engine;
 //     char data[];
 //   } blobs[];
 //
-//   // These two are not signed:
-//   uint64 signatures_message_size;
+//   // The signature covers all preceding data. Size and location are
+//   // specified inside the manifest.
 //   char signatures_message[];
 //
 // };

--- a/src/update_engine/update_metadata.proto
+++ b/src/update_engine/update_metadata.proto
@@ -130,6 +130,7 @@ message InstallInfo {
 message InstallProcedure {
   enum Type {
     KERNEL = 0;  // A kernel image to install to the boot partition.
+    PCR_POLICY = 1;  // A zip file containing TPM PCR data.
   }
   optional Type type = 1;
 

--- a/src/update_engine/update_metadata.proto
+++ b/src/update_engine/update_metadata.proto
@@ -73,7 +73,7 @@ message InstallOperation {
   // that bsdiff writes with '\0' bytes.
   optional uint64 dst_length = 7;
 
-  // Optional SHA 256 hash of the blob associated with this operation.
+  // Required SHA 256 hash of the blob associated with this operation.
   // This is used as a primary validation for http-based downloads and
   // as a defense-in-depth validation for https-based downloads. If
   // the operation doesn't refer to any blob, this field will have

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -695,6 +695,8 @@ string CodeToString(ActionExitCode code) {
       return "kActionCodePostinstallPowerwashError";
     case kActionCodeNewPCRPolicyVerificationError:
       return "kActionCodeNewPCRPolicyVerificationError";
+    case kActionCodeNewPCRPolicyHTTPError:
+      return "kActionCodeNewPCRPolicyHTTPError";
     case kActionCodeDownloadIncomplete:
       return "kActionCodeDownloadIncomplete";
     case kActionCodeOmahaRequestHTTPResponseBase:

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -693,6 +693,8 @@ string CodeToString(ActionExitCode code) {
       return "kActionCodeOmahaUpdateDeferredForBackoff";
     case kActionCodePostinstallPowerwashError:
       return "kActionCodePostinstallPowerwashError";
+    case kActionCodeNewPCRPolicyVerificationError:
+      return "kActionCodeNewPCRPolicyVerificationError";
     case kActionCodeDownloadIncomplete:
       return "kActionCodeDownloadIncomplete";
     case kActionCodeOmahaRequestHTTPResponseBase:

--- a/src/update_engine/utils.h
+++ b/src/update_engine/utils.h
@@ -386,6 +386,14 @@ class ScopedActionCompleter {
     }                                                                          \
   } while (0)
 
+#define TEST_AND_RETURN_VAL(_retval, _x)                                       \
+  do {                                                                         \
+    bool _success = (_x);                                                      \
+    if (!_success) {                                                           \
+      LOG(ERROR) << #_x " failed.";                                            \
+      return _retval;                                                          \
+    }                                                                          \
+  } while (0)
 
 
 #endif  // CHROMEOS_PLATFORM_UPDATE_ENGINE_UTILS_H__


### PR DESCRIPTION
Adds a new update payload data type that will contain [coreos_production_image_pcr_policy.zip](https://alpha.release.core-os.net/amd64-usr/current/coreos_production_image_pcr_policy.zip) and a new `/etc/coreos/update.conf` option `PCR_POLICY_SERVER`. When set update_engine will POST the policy zip to the given URL.