### PR TITLE
omaha_request_params: accept alternate location of oem-release

### DIFF
--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -95,6 +95,7 @@ string OmahaRequestParams::GetOemValue(const string& key,
                                        const string& default_value) const {
   vector<string> files;
   files.push_back("/etc/oem-release");
+  files.push_back("/usr/share/oem/oem-release");
   return SearchConfValue(files, key, default_value);
 }
 


### PR DESCRIPTION
The new ignition based GCE OEM installs oem-release to /usr/share/oem
but not /etc as it did in the past. Fix reporting OEM on these systems.