### PR TITLE
Skip call to coreos-setgoodroot if an update has already been completed

### DIFF
--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -115,8 +115,10 @@ UpdateAttempter::UpdateAttempter(SystemState* system_state,
       start_action_processor_(false) {
   prefs_ = system_state->prefs();
   omaha_request_params_ = system_state->request_params();
-  if (utils::FileExists(kUpdateCompletedMarker))
+  if (utils::FileExists(kUpdateCompletedMarker)){
     status_ = UPDATE_STATUS_UPDATED_NEED_REBOOT;
+    updated_boot_flags_(true);
+  }
 }
 
 void UpdateAttempter::Update(bool interactive) {

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -115,9 +115,9 @@ UpdateAttempter::UpdateAttempter(SystemState* system_state,
       start_action_processor_(false) {
   prefs_ = system_state->prefs();
   omaha_request_params_ = system_state->request_params();
-  if (utils::FileExists(kUpdateCompletedMarker)){
+  if (utils::FileExists(kUpdateCompletedMarker)) {
     status_ = UPDATE_STATUS_UPDATED_NEED_REBOOT;
-    updated_boot_flags_(true);
+    updated_boot_flags_ = true;
   }
 }
 


### PR DESCRIPTION
…EED_REBOOT then update-engine.service should not update the priority flags.