### PR TITLE
Report version information

### DIFF
--- a/src/update_engine/install_plan.h
+++ b/src/update_engine/install_plan.h
@@ -58,6 +58,9 @@ struct InstallPlan {
   uint64_t new_pcr_policy_size;
   std::vector<char> new_pcr_policy_hash;
 
+  // Optional version of the update being applied.
+  std::string display_version;
+
   // Optional arguments to pass to the post install script. Used to inform
   // the script about optional update procedures that ran. For example
   // "KERNEL=kernel_path" indicates that update_engine installed the kernel

--- a/src/update_engine/omaha_request_action.cc
+++ b/src/update_engine/omaha_request_action.cc
@@ -46,7 +46,7 @@ static const char* kTagSha256 = "sha256";
 
 namespace {
 
-const string kGupdateVersion("CoreOSUpdateEngine-0.1.0.0");
+const string kGupdateVersion(PACKAGE_NAME "-" PACKAGE_VERSION);
 
 // This is handy for passing strings into libxml2
 #define ConstXMLStr(x) (reinterpret_cast<const xmlChar*>(x))

--- a/src/update_engine/omaha_request_action.cc
+++ b/src/update_engine/omaha_request_action.cc
@@ -30,7 +30,7 @@ namespace chromeos_update_engine {
 // List of custom pair tags that we interpret in the Omaha Response:
 static const char* kTagDeadline = "deadline";
 static const char* kTagDisablePayloadBackoff = "DisablePayloadBackoff";
-static const char* kTagDisplayVersion = "DisplayVersion";
+// Deprecated: "DisplayVersion"
 // Deprecated: "IsDelta"
 static const char* kTagIsDeltaPayload = "IsDeltaPayload";
 static const char* kTagMaxFailureCountPerUrl = "MaxFailureCountPerUrl";
@@ -350,6 +350,9 @@ bool OmahaRequestAction::ParseResponse(xmlDoc* doc,
   if (!ParseStatus(update_check_node, output_object, completer))
     return false;
 
+  if (!ParseManifest(doc, output_object, completer))
+    return false;
+
   // Note: ParseUrls MUST be called before ParsePackage as ParsePackage
   // appends the package name to the URLs populated in this method.
   if (!ParseUrls(doc, output_object, completer))
@@ -392,6 +395,34 @@ bool OmahaRequestAction::ParseStatus(xmlNode* update_check_node,
     completer->set_code(kActionCodeOmahaResponseInvalid);
     return false;
   }
+
+  return true;
+}
+
+bool OmahaRequestAction::ParseManifest(xmlDoc* doc,
+                                       OmahaResponse* output_object,
+                                       ScopedActionCompleter* completer) {
+  // Get the manifest node.
+  static const char* kManifestNodeXPath("/response/app/updatecheck/manifest");
+
+  std::unique_ptr<xmlXPathObject, ScopedPtrXmlXPathObjectFree>
+      xpath_nodeset(GetNodeSet(doc, ConstXMLStr(kManifestNodeXPath)));
+  if (!xpath_nodeset.get()) {
+    completer->set_code(kActionCodeOmahaResponseInvalid);
+    return false;
+  }
+
+  xmlNodeSet* nodeset = xpath_nodeset->nodesetval;
+  CHECK(nodeset) << "XPath missing " << kManifestNodeXPath;
+  CHECK_GE(nodeset->nodeNr, 1);
+
+  // We only care about the first (and only hopefully) manifest.
+  xmlNode* manifest_node = nodeset->nodeTab[0];
+
+  // Parse the version, only used for informational purposes.
+  const string version(XmlGetProperty(manifest_node, "version"));
+  LOG(INFO) << "Omaha Response manifest version = " << version;
+  output_object->display_version = version;
 
   return true;
 }
@@ -532,8 +563,6 @@ bool OmahaRequestAction::ParseParams(xmlDoc* doc,
   }
 
   // Get the optional properties one by one.
-  output_object->display_version =
-      XmlGetProperty(pie_action_node, kTagDisplayVersion);
   output_object->more_info_url = XmlGetProperty(pie_action_node, kTagMoreInfo);
   output_object->needs_admin =
       XmlGetProperty(pie_action_node, kTagNeedsAdmin) == "true";

--- a/src/update_engine/omaha_request_action.h
+++ b/src/update_engine/omaha_request_action.h
@@ -152,6 +152,13 @@ class OmahaRequestAction : public Action<OmahaRequestAction>,
                    OmahaResponse* output_object,
                    ScopedActionCompleter* completer);
 
+  // Parses the version attribute on manifest XML node and populates
+  // |output_object| if valid. Returns true if we should continue the parsing.
+  // False otherwise, in which case it sets any error code using |completer|.
+  bool ParseManifest(xmlDoc* doc,
+                     OmahaResponse* output_object,
+                     ScopedActionCompleter* completer);
+
   // Parses the URL nodes in the given XML document and populates
   // |output_object| if valid. Returns true if we should continue the parsing.
   // False otherwise, in which case it sets any error code using |completer|.

--- a/src/update_engine/omaha_request_action_unittest.cc
+++ b/src/update_engine/omaha_request_action_unittest.cc
@@ -85,8 +85,6 @@ string GetUpdateResponse2(const string& app_id,
       "<packages><package hash=\"not-used\" name=\"" + filename +  "\" "
       "size=\"" + size + "\"/></packages>"
       "<actions><action event=\"postinstall\" "
-      "DisplayVersion=\"" + display_version + "\" "
-      "ChromeOSVersion=\"" + display_version + "\" "
       "MoreInfo=\"" + more_info_url + "\" Prompt=\"" + prompt + "\" "
       "IsDelta=\"true\" "
       "IsDeltaPayload=\"true\" "
@@ -353,8 +351,6 @@ TEST(OmahaRequestActionTest, MissingFieldTest) {
       "<packages><package hash=\"not-used\" name=\"f\" "
       "size=\"587\"/></packages>"
       "<actions><action event=\"postinstall\" "
-      "DisplayVersion=\"10.2.3.4\" "
-      "ChromeOSVersion=\"10.2.3.4\" "
       "Prompt=\"false\" "
       "IsDelta=\"true\" "
       "IsDeltaPayload=\"false\" "
@@ -373,7 +369,7 @@ TEST(OmahaRequestActionTest, MissingFieldTest) {
                               &response,
                               NULL));
   EXPECT_TRUE(response.update_exists);
-  EXPECT_EQ("10.2.3.4", response.display_version);
+  EXPECT_EQ("1.0.0.0", response.display_version);
   EXPECT_EQ("http://missing/field/test/f", response.payload_urls[0]);
   EXPECT_EQ("", response.more_info_url);
   EXPECT_EQ("lkq34j5345", response.hash);

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -45,6 +45,7 @@ void OmahaResponseHandlerAction::PerformAction() {
   install_plan_.download_url = response.payload_urls[url_index];
 
   // Fill up the other properties based on the response.
+  install_plan_.display_version = response.display_version;
   install_plan_.payload_size = response.size;
   install_plan_.payload_hash = response.hash;
   install_plan_.is_resume =

--- a/src/update_engine/omaha_response_handler_action_unittest.cc
+++ b/src/update_engine/omaha_response_handler_action_unittest.cc
@@ -97,6 +97,7 @@ TEST_F(OmahaResponseHandlerActionTest, SimpleTest) {
     EXPECT_TRUE(DoTest(in, "/dev/sda3", &install_plan));
     EXPECT_EQ(in.payload_urls[0], install_plan.download_url);
     EXPECT_EQ(in.hash, install_plan.payload_hash);
+    EXPECT_EQ(in.display_version, install_plan.display_version);
     EXPECT_EQ("/dev/sda4", install_plan.partition_path);
     string deadline;
     EXPECT_TRUE(utils::ReadFile(
@@ -123,6 +124,7 @@ TEST_F(OmahaResponseHandlerActionTest, SimpleTest) {
     EXPECT_TRUE(DoTest(in, "/dev/sda4", &install_plan));
     EXPECT_EQ(in.payload_urls[0], install_plan.download_url);
     EXPECT_EQ(in.hash, install_plan.payload_hash);
+    EXPECT_EQ(in.display_version, install_plan.display_version);
     EXPECT_EQ("/dev/sda3", install_plan.partition_path);
     string deadline;
     EXPECT_TRUE(utils::ReadFile(
@@ -144,6 +146,7 @@ TEST_F(OmahaResponseHandlerActionTest, SimpleTest) {
     EXPECT_TRUE(DoTest(in, "/dev/sda3", &install_plan));
     EXPECT_EQ(in.payload_urls[0], install_plan.download_url);
     EXPECT_EQ(in.hash, install_plan.payload_hash);
+    EXPECT_EQ(in.display_version, install_plan.display_version);
     EXPECT_EQ("/dev/sda4", install_plan.partition_path);
     string deadline;
     EXPECT_TRUE(utils::ReadFile(

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -378,8 +378,7 @@ void UpdateAttempter::ActionCompleted(ActionProcessor* processor,
     CHECK(action == response_handler_action_.get());
     const InstallPlan& plan = response_handler_action_->install_plan();
     last_checked_time_ = time(NULL);
-    // TODO(adlr): put version in InstallPlan
-    new_version_ = "0.0.0.0";
+    new_version_ = plan.display_version;
     new_payload_size_ = plan.payload_size;
     SetupDownload();
     SetStatusAndNotify(UPDATE_STATUS_UPDATE_AVAILABLE,


### PR DESCRIPTION
 - submit actual update_engine version in omaha requests
 - pass version through from omaha response to dbus status messages and so on