### PR TITLE
Small fixes for update status reporting

### DIFF
--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -51,6 +51,8 @@ const int UpdateAttempter::kMaxDeltaUpdateFailures = 3;
 const char* kUpdateCompletedMarker =
     "/var/run/update_engine_autoupdate_completed";
 
+const char* kVersionZero = "0.0.0";
+
 const char* UpdateStatusToString(UpdateStatus status) {
   switch (status) {
     case UPDATE_STATUS_IDLE:
@@ -108,7 +110,7 @@ UpdateAttempter::UpdateAttempter(SystemState* system_state,
       status_(UPDATE_STATUS_IDLE),
       download_progress_(0.0),
       last_checked_time_(0),
-      new_version_("0.0.0.0"),
+      new_version_(kVersionZero),
       new_payload_size_(0),
       updated_boot_flags_(false),
       update_boot_flags_running_(false),
@@ -291,6 +293,9 @@ void UpdateAttempter::ProcessingDone(const ActionProcessor* processor,
   if (status_ == UPDATE_STATUS_REPORTING_ERROR_EVENT) {
     LOG(INFO) << "Error event sent.";
 
+    new_payload_size_ = 0;
+    new_version_ = kVersionZero;
+
     // Inform scheduler of new status
     SetStatusAndNotify(UPDATE_STATUS_IDLE, kUpdateNoticeUnspecified);
 
@@ -324,6 +329,8 @@ void UpdateAttempter::ProcessingDone(const ActionProcessor* processor,
 
 void UpdateAttempter::ProcessingStopped(const ActionProcessor* processor) {
   download_progress_ = 0.0;
+  new_payload_size_ = 0;
+  new_version_ = kVersionZero;
   SetStatusAndNotify(UPDATE_STATUS_IDLE, kUpdateNoticeUnspecified);
   actions_.clear();
   error_event_.reset(NULL);
@@ -434,6 +441,8 @@ bool UpdateAttempter::ResetStatus() {
       return true;
 
     case UPDATE_STATUS_UPDATED_NEED_REBOOT:  {
+      new_payload_size_ = 0;
+      new_version_ = kVersionZero;
       status_ = UPDATE_STATUS_IDLE;
       LOG(INFO) << "Reset Successful";
 

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -356,6 +356,9 @@ void UpdateAttempter::ActionCompleted(ActionProcessor* processor,
     // If the request is not an event, then it's the update-check.
     if (!omaha_request_action->IsEvent()) {
       http_response_code_ = omaha_request_action->GetHTTPResponseCode();
+      if (code == kActionCodeSuccess) {
+	last_checked_time_ = time(NULL);
+      }
       // Forward the server-dictated poll interval to the update check
       // scheduler, if any.
       if (update_check_scheduler_) {
@@ -384,7 +387,6 @@ void UpdateAttempter::ActionCompleted(ActionProcessor* processor,
     // cases when the server and the client are unable to initiate the download.
     CHECK(action == response_handler_action_.get());
     const InstallPlan& plan = response_handler_action_->install_plan();
-    last_checked_time_ = time(NULL);
     new_version_ = plan.display_version;
     new_payload_size_ = plan.payload_size;
     SetupDownload();

--- a/src/update_engine/update_attempter.h
+++ b/src/update_engine/update_attempter.h
@@ -29,6 +29,7 @@ namespace chromeos_update_engine {
 class UpdateCheckScheduler;
 
 extern const char* kUpdateCompletedMarker;
+extern const char* kVersionZero;
 
 enum UpdateStatus {
   UPDATE_STATUS_IDLE = 0,

--- a/src/update_engine/update_attempter_unittest.cc
+++ b/src/update_engine/update_attempter_unittest.cc
@@ -67,7 +67,7 @@ class UpdateAttempterTest : public ::testing::Test {
     EXPECT_EQ(UPDATE_STATUS_IDLE, attempter_.status_);
     EXPECT_EQ(0.0, attempter_.download_progress_);
     EXPECT_EQ(0, attempter_.last_checked_time_);
-    EXPECT_EQ("0.0.0.0", attempter_.new_version_);
+    EXPECT_EQ(kVersionZero, attempter_.new_version_);
     EXPECT_EQ(0, attempter_.new_payload_size_);
     processor_ = new NiceMock<ActionProcessorMock>();
     attempter_.processor_.reset(processor_);  // Transfers ownership.


### PR DESCRIPTION
 - Clear new version/size fields when idle
 - Update last check time for "noupdate" responses

Fixes https://github.com/coreos/bugs/issues/1666