### PR TITLE
coreos-postinst: patch platform.py in python libs

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -114,6 +114,19 @@ EOF
     systemctl start --no-block locksmithd-kicker.timer
 fi
 
+# Azure's agent erroneously looks at the distribution name instead of its ID.
+# This prevents us from renaming the OS from "CoreOS". This patches platform.py
+# to always return "CoreOS" as the distribution name.
+PLATFORM_PATH="/usr/share/oem/python/lib64/python2.7/platform.py"
+if [ -e ${PLATFORM_PATH} ]; then
+    sum=($(md5sum ${PLATFORM_PATH}))
+    if [ ${sum} == "6315addf42c0b07f5f78d119b578e20a" ]; then
+        sed --in-place \
+            "s%distname = os_release_info\['NAME'\]%distname = \"CoreOS\"%" \
+            ${PLATFORM_PATH}
+    fi
+fi
+
 # use the cgpt binary from the image to ensure compatibility
 CGPT=
 for bindir in bin/old_bins bin sbin; do


### PR DESCRIPTION
Azure's agent erroneously looks at the distribution name instead of its
ID. In order to rename the OS to "Container Linux", this fix is needed
to force python to always report the OS's name as "CoreOS".

This will apply to all of the OEMs where we ship python (historically,
Azure and GCE), but Azure is the only one who uses these APIs.
Eventually, the Azure agent will be updated to read the ID instead of
the name, making this unnecessary on newer instances. Unfortunately,
since we don't update the OEM partition, there will always be older
agents who require this fix.