### PR TITLE
systemd: use multi-user.target instead of default.target

### DIFF
--- a/systemd/update-engine-stub.service
+++ b/systemd/update-engine-stub.service
@@ -8,4 +8,4 @@ Type=oneshot
 ExecStart=/usr/sbin/update_engine_stub
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/systemd/update-engine-stub.timer
+++ b/systemd/update-engine-stub.timer
@@ -9,4 +9,4 @@ OnActiveSec=41minutes
 Unit=update-engine-stub.service
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/systemd/update-engine.service
+++ b/systemd/update-engine.service
@@ -12,4 +12,4 @@ Restart=always
 RestartSec=30
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
These `Install` sections aren't actually used, the instead the ebuild
already enables the units using multi-user.target. Nevertheless using
default.target can cause problems and so should be fixed for the sake of
documentation and consistency.

See coreos/coreos-overlay#2484 for an example of default.target breaking.