### PR TITLE
Add a Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,96 @@
+#!groovy
+
+properties([
+    buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '50')),
+    pipelineTriggers([pollSCM('H/20 * * * *')])
+])
+
+node('amd64 && coreos && sudo') {
+    stage('Prepare') {
+        sh 'sudo rm -fr coreos_developer_container.bin source wd'
+
+        dir('source') {
+            checkout scm
+        }
+
+        sh '''#!/bin/bash -ex
+version_url="https://alpha.release.core-os.net/amd64-usr/current"
+container_url="$version_url/coreos_developer_container.bin.bz2"
+
+# Download and verify the developer container image.
+gpg2 --recv-keys 04127D0BFABEC8871FFB2CCE50E0885593D2DCB4 || :
+curl --fail --location "$container_url" |
+tee >(bzip2 --decompress > coreos_developer_container.bin) |
+gpg2 --verify <(curl --location --silent "$container_url.sig") -
+
+# Define the Jenkins user in the container, and install build dependencies.
+sudo mount -o offset=2097152,x-mount.mkdir coreos_developer_container.bin wd
+trap 'sudo umount -d wd' EXIT
+sudo cp /etc/resolv.conf wd/etc/
+sudo chroot wd /bin/bash -ex << EOF
+mount -t devtmpfs devtmpfs /dev
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+trap 'umount /dev /proc /sys' EXIT
+echo $(getent passwd $(id -u)) >> /etc/passwd
+echo $(getent group $(id -g)) >> /etc/group
+usermod -aG sudo $USER
+cat << EOG > /etc/pam.d/sudo
+account optional pam_permit.so
+auth optional pam_permit.so
+password optional pam_permit.so
+session optional pam_permit.so
+EOG
+emerge-gitclone
+emerge -j4 -v dev-cpp/gmock dev-util/pkgconfig sys-devel/autoconf
+mkdir /usr/src
+EOF
+sudo mv source wd/usr/src/update_engine
+'''
+    }
+
+    stage('Build') {
+        sh '''#!/bin/bash -ex
+sudo mount -o offset=2097152 coreos_developer_container.bin wd
+trap 'sudo umount -d wd' EXIT
+sudo chroot --userspec=$(id -u):$(id -g) wd /bin/bash -ex << 'EOF'
+sudo mount -t devtmpfs devtmpfs /dev
+sudo mount -t proc proc /proc
+sudo mount -t sysfs sysfs /sys
+trap 'sudo umount /dev /proc /sys' EXIT
+cd /usr/src/update_engine
+./autogen.sh
+./configure --enable-debug
+make -j4 all
+EOF
+'''
+    }
+
+    stage('Test') {
+        def rc = sh returnStatus: true, script: '''#!/bin/bash -ex
+sudo mount -o offset=2097152 coreos_developer_container.bin wd
+trap 'sudo umount -d wd' EXIT
+sudo chroot --userspec=$(id -u):$(id -g) wd /bin/bash -ex << 'EOF'
+sudo mount -t devtmpfs devtmpfs /dev
+sudo mount -t proc proc /proc
+sudo mount -t sysfs sysfs /sys
+trap 'sudo umount /dev /proc /sys' EXIT
+cd /usr/src/update_engine
+make -j4 \
+    update_engine_unittests \
+    test_http_server \
+    unittest_key.pub.pem \
+    unittest_key2.pub.pem
+GTEST_OUTPUT="xml:$PWD/user.xml" ./run_unittests_as_user
+sudo GTEST_OUTPUT="xml:$PWD/root.xml" ./run_unittests_as_root
+EOF
+sudo mv wd/usr/src/update_engine source
+'''
+
+        archiveArtifacts 'source/root.xml,source/user.xml'
+
+        junit 'source/root.xml,source/user.xml'
+
+        currentBuild.result = rc == 0 ? 'SUCCESS' : 'FAILURE'
+    }
+}

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ check_DATA =
 CLEANFILES = $(BUILT_SOURCES) $(check_DATA)
 EXTRA_DIST =
 
-AM_CPPFLAGS = -I$(srcdir)/src -I$(builddir)/src
+AM_CPPFLAGS = -I$(srcdir)/src -I$(builddir)/src $(GTEST_CPPFLAGS) $(GMOCK_CPPFLAGS)
 AM_CFLAGS = -fno-exceptions \
 	    -fno-strict-aliasing \
 	    -Wall \
@@ -123,7 +123,7 @@ libupdate_engine_a_SOURCES = \
 	src/update_engine/utils.cc
 
 update_engine_unittests_LDADD = libupdate_engine.a \
-				-lgtest -lgmock $(LDADD)
+				$(GTEST_LIBS) $(GMOCK_LIBS) $(LDADD)
 update_engine_unittests_SOURCES = \
 	src/update_engine/testrunner.cc \
 	src/files/file_path_unittest.cc \

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,26 @@ PKG_CHECK_MODULES([DEPS],
                    libxml-2.0
                    protobuf])
 
+AC_CHECK_TOOL([GTEST_CONFIG], [gtest-config], [:])
+AS_IF([test "x${GTEST_CONFIG}" = "x:"],
+      [AC_MSG_ERROR([*** gtest not found])])
+AC_ARG_VAR([GTEST_CPPFLAGS], [CPPFLAGS for compiling with gtest])
+AC_ARG_VAR([GTEST_LIBS], [LIBS for linking with gtest])
+test -n "$GTEST_CPPFLAGS" || GTEST_CPPFLAGS=$($GTEST_CONFIG --cppflags)
+test -n "$GTEST_LIBS" || GTEST_LIBS=$($GTEST_CONFIG --libs)
+AC_SUBST([GTEST_CPPFLAGS])
+AC_SUBST([GTEST_LIBS])
+
+AC_CHECK_TOOL([GMOCK_CONFIG], [gmock-config], [:])
+AS_IF([test "x${GMOCK_CONFIG}" = "x:"],
+      [AC_MSG_ERROR([*** gmock not found])])
+AC_ARG_VAR([GMOCK_CPPFLAGS], [CPPFLAGS for compiling with gmock])
+AC_ARG_VAR([GMOCK_LIBS], [LIBS for linking with gmock])
+test -n "$GMOCK_CPPFLAGS" || GMOCK_CPPFLAGS=$($GMOCK_CONFIG --cppflags)
+test -n "$GMOCK_LIBS" || GMOCK_LIBS=$($GMOCK_CONFIG --libs)
+AC_SUBST([GMOCK_CPPFLAGS])
+AC_SUBST([GMOCK_LIBS])
+
 # Make sure logging can be configured with command line flags. If glog
 # was built with gflags support it will include the gflags header.
 AC_MSG_CHECKING([glog uses gflags])


### PR DESCRIPTION
This also makes `configure` test `gmock` and `gtest` development files.  They don't look like they are intended to be used outside tests, but a header is always included which fails the regular build if they're not present, so always require them.