### PR TITLE
service: drop file

### DIFF
--- a/com.coreos.update1.service
+++ b/com.coreos.update1.service
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=com.coreos.update1
-Exec=/usr/sbin/update_engine


### PR DESCRIPTION
We only listen on the system bus, and the `User` key is mandatory there.  Thus this file has never been relevant. It's too late to add `User` and `SystemdService` keys and start using proper bus activation, because we [document](https://coreos.com/os/docs/latest/update-strategies.html#disable-automatic-updates-daemon) that stopping `update-engine.service` will prevent updates from occurring until the machine is rebooted.

cc @euank