### PR TITLE
Move daemon and stub to /usr/libexec

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,15 +37,16 @@ AM_CFLAGS += -fprofile-arcs -ftest-coverage
 LDADD += -lgcov
 endif
 
-sbin_PROGRAMS = update_engine
+libexec_PROGRAMS = update_engine
 bin_PROGRAMS = update_engine_client
 if ENABLE_DELTA_GENERATOR
 bin_PROGRAMS += delta_generator
 endif
 
 sbin_SCRIPTS = coreos-postinst \
-	       coreos-setgoodroot \
-	       systemd/update_engine_stub
+	       coreos-setgoodroot
+
+libexec_SCRIPTS= systemd/update_engine_stub
 
 noinst_LIBRARIES = libupdate_engine.a
 

--- a/systemd/update-engine-stub.service
+++ b/systemd/update-engine-stub.service
@@ -5,7 +5,7 @@ ConditionPathExists=/usr/.noupdate
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/update_engine_stub
+ExecStart=/usr/libexec/update_engine_stub
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/update-engine.service
+++ b/systemd/update-engine.service
@@ -6,7 +6,7 @@ ConditionPathExists=!/usr/.noupdate
 [Service]
 Type=dbus
 BusName=com.coreos.update1
-ExecStart=/usr/sbin/update_engine -foreground -logtostderr
+ExecStart=/usr/libexec/update_engine -foreground -logtostderr
 BlockIOWeight=100
 Restart=always
 RestartSec=30


### PR DESCRIPTION
I was spending some time investigating how `update_engine` works, and when first
starting out it took me a little bit to figure out that there were separate
`update_engine_client` vs `update_engine`. Having them both in `/usr/sbin` is
annoying for bash completion.

This is just a minor "papercut"; I'm mostly using this to test running
through the development/contribution process.

I am assuming nothing tries to find these binaries directly and only uses the
systemd service and/or DBus API; I didn't see any obvious hits in `repo grep
update_engine`.

Signed-off-by: Colin Walters <walters@verbum.org>