### PR TITLE
Fix warnings with new GCCs and glibcs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([update_engine],[0.4.2],[https://github.com/coreos/bugs/issues])
+AC_INIT([update_engine],[0.4.6],[https://github.com/coreos/bugs/issues])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_SRCDIR([src/update_engine/main.cc])
 AC_USE_SYSTEM_EXTENSIONS

--- a/configure.ac
+++ b/configure.ac
@@ -85,23 +85,17 @@ PKG_CHECK_MODULES([DEPS],
                    libxml-2.0
                    protobuf])
 
-AC_CHECK_TOOL([GTEST_CONFIG], [gtest-config], [:])
-AS_IF([test "x${GTEST_CONFIG}" = "x:"],
-      [AC_MSG_ERROR([*** gtest not found])])
 AC_ARG_VAR([GTEST_CPPFLAGS], [CPPFLAGS for compiling with gtest])
 AC_ARG_VAR([GTEST_LIBS], [LIBS for linking with gtest])
-test -n "$GTEST_CPPFLAGS" || GTEST_CPPFLAGS=$($GTEST_CONFIG --cppflags)
-test -n "$GTEST_LIBS" || GTEST_LIBS=$($GTEST_CONFIG --libs)
+test -n "$GTEST_CPPFLAGS" || GTEST_CPPFLAGS=
+test -n "$GTEST_LIBS" || GTEST_LIBS=-lgtest
 AC_SUBST([GTEST_CPPFLAGS])
 AC_SUBST([GTEST_LIBS])
 
-AC_CHECK_TOOL([GMOCK_CONFIG], [gmock-config], [:])
-AS_IF([test "x${GMOCK_CONFIG}" = "x:"],
-      [AC_MSG_ERROR([*** gmock not found])])
 AC_ARG_VAR([GMOCK_CPPFLAGS], [CPPFLAGS for compiling with gmock])
 AC_ARG_VAR([GMOCK_LIBS], [LIBS for linking with gmock])
-test -n "$GMOCK_CPPFLAGS" || GMOCK_CPPFLAGS=$($GMOCK_CONFIG --cppflags)
-test -n "$GMOCK_LIBS" || GMOCK_LIBS=$($GMOCK_CONFIG --libs)
+test -n "$GMOCK_CPPFLAGS" || GMOCK_CPPFLAGS=
+test -n "$GMOCK_LIBS" || GMOCK_LIBS=-lgmock
 AC_SUBST([GMOCK_CPPFLAGS])
 AC_SUBST([GMOCK_LIBS])
 

--- a/src/files/file_enumerator_posix.cc
+++ b/src/files/file_enumerator_posix.cc
@@ -123,9 +123,8 @@ bool FileEnumerator::ReadDirectory(std::vector<FileInfo>* entries,
          additional space for pathname may be needed
 #endif
 
-  struct dirent dent_buf;
   struct dirent* dent;
-  while (readdir_r(dir, &dent_buf, &dent) == 0 && dent) {
+  while ((dent = readdir(dir)) != NULL) {
     FileInfo info;
     info.filename_ = FilePath(dent->d_name);
 

--- a/src/strings/string_split_unittest.cc
+++ b/src/strings/string_split_unittest.cc
@@ -149,10 +149,12 @@ TEST(StringSplitTest, SplitWords) {
   for (size_t i = 0; i < arraysize(data); ++i) {
     std::vector<std::string> results = SplitWords(data[i].input);
     ASSERT_EQ(data[i].expected_result_count, results.size());
-    if (data[i].expected_result_count > 0)
+    if (data[i].expected_result_count > 0) {
       ASSERT_EQ(data[i].output1, results[0]);
-    if (data[i].expected_result_count > 1)
+    }
+    if (data[i].expected_result_count > 1) {
       ASSERT_EQ(data[i].output2, results[1]);
+    }
   }
 }
 

--- a/src/update_engine/download_action_unittest.cc
+++ b/src/update_engine/download_action_unittest.cc
@@ -280,8 +280,9 @@ void TestTerminateEarly(bool use_download_delegate) {
   // 1 or 0 chunks should have come through
   const off_t resulting_file_size(utils::FileSize(temp_file.GetPath()));
   EXPECT_GE(resulting_file_size, 0);
-  if (resulting_file_size != 0)
+  if (resulting_file_size != 0) {
     EXPECT_EQ(kMockHttpFetcherChunkSize, resulting_file_size);
+  }
 }
 
 }  // namespace {}

--- a/src/update_engine/filesystem_iterator.cc
+++ b/src/update_engine/filesystem_iterator.cc
@@ -111,11 +111,10 @@ void FilesystemIterator::Increment() {
 void FilesystemIterator::IncrementInternal() {
   CHECK_EQ(dirs_.size(), names_.size() + 1);
   for (;;) {
-    struct dirent dir_entry;
     struct dirent* dir_entry_pointer;
-    int r;
+    errno = 0;
     RETURN_ERROR_IF_FALSE(
-        (r = readdir_r(dirs_.back(), &dir_entry, &dir_entry_pointer)) == 0);
+        (dir_entry_pointer = readdir(dirs_.back())) != NULL || errno == 0);
     if (dir_entry_pointer) {
       // Found an entry
       names_.push_back(dir_entry_pointer->d_name);

--- a/src/update_engine/http_fetcher_unittest.cc
+++ b/src/update_engine/http_fetcher_unittest.cc
@@ -141,8 +141,9 @@ class PythonHttpServer : public HttpServer {
     int rc = system((string("wget -t 1 --output-document=/dev/null ") +
                      LocalServerUrlForPath("/quitquitquit")).c_str());
     LOG(INFO) << "done running wget to exit";
-    if (validate_quit_)
+    if (validate_quit_) {
       EXPECT_EQ(0, rc);
+    }
     LOG(INFO) << "waiting for http server with pid " << pid_ << " to terminate";
     int status;
     waitpid(pid_, &status, 0);
@@ -824,8 +825,9 @@ class MultiHttpFetcherTestDelegate : public HttpFetcherDelegate {
   virtual void TransferComplete(HttpFetcher* fetcher, bool successful) {
     EXPECT_EQ(fetcher, fetcher_.get());
     EXPECT_EQ(expected_response_code_ != kHttpResponseUndefined, successful);
-    if (expected_response_code_ != 0)
+    if (expected_response_code_ != 0) {
       EXPECT_EQ(expected_response_code_, fetcher->http_response_code());
+    }
     // Destroy the fetcher (because we're allowed to).
     fetcher_.reset(NULL);
     g_main_loop_quit(loop_);

--- a/src/update_engine/postinstall_runner_action_unittest.cc
+++ b/src/update_engine/postinstall_runner_action_unittest.cc
@@ -127,8 +127,9 @@ void PostinstallRunnerActionTest::DoTest(bool do_losetup, int err_code) {
   if (do_losetup && !err_code) {
     EXPECT_TRUE(install_plan == collector_action.object());
   }
-  if (err_code == 2)
+  if (err_code == 2) {
     EXPECT_EQ(kActionCodePostinstallBootedFromFirmwareB, delegate.code());
+  }
 
   struct stat stbuf;
   int rc = lstat((string(cwd) + "/postinst_called").c_str(), &stbuf);

--- a/src/update_engine/simple_key_value_store_unittest.cc
+++ b/src/update_engine/simple_key_value_store_unittest.cc
@@ -40,8 +40,9 @@ TEST(SimpleKeyValueStoreTest, EmptyTest) {
   map<string, string> empty_map = simple_key_value_store::ParseString("");
   EXPECT_TRUE(empty_map.empty());
   string str = simple_key_value_store::AssembleString(empty_map);
-  if (!str.empty())
+  if (!str.empty()) {
     EXPECT_EQ("\n", str);  // Optionally may end in newline
+  }
 }
 
 }  // namespace chromeos_update_engine

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -290,14 +290,9 @@ bool RecursiveUnlinkDir(const std::string& path) {
     DIR *dir = opendir(path.c_str());
     TEST_AND_RETURN_FALSE_ERRNO(dir);
     ScopedDirCloser dir_closer(&dir);
-    struct dirent dir_entry;
     struct dirent *dir_entry_p;
-    int err = 0;
-    while ((err = readdir_r(dir, &dir_entry, &dir_entry_p)) == 0) {
-      if (dir_entry_p == NULL) {
-        // end of stream reached
-        break;
-      }
+    errno = 0;
+    while ((dir_entry_p = readdir(dir)) != NULL) {
       // Skip . and ..
       if (!strcmp(dir_entry_p->d_name, ".") ||
           !strcmp(dir_entry_p->d_name, ".."))
@@ -305,7 +300,7 @@ bool RecursiveUnlinkDir(const std::string& path) {
       TEST_AND_RETURN_FALSE(RecursiveUnlinkDir(path + "/" +
                                                dir_entry_p->d_name));
     }
-    TEST_AND_RETURN_FALSE(err == 0);
+    TEST_AND_RETURN_FALSE(errno == 0);
   }
   // unlink dir
   TEST_AND_RETURN_FALSE_ERRNO((rmdir(path.c_str()) == 0) || (errno == ENOENT));


### PR DESCRIPTION
This fixes warnings when building with recent glibc versions.

Part of coreos/coreos-overlay#2886