### PR TITLE
coreos-postinst: copy libprocps.so.3 into OEM partition if needed

### DIFF
--- a/coreos-postinst
+++ b/coreos-postinst
@@ -313,6 +313,19 @@ function patch_grub {
 
 patch_grub
 
+# The vmware OEM on Container Linux 490.0.0 - 1353.8.0 includes a build of
+# open-vm-tools with a dlopened plugin that links with the libprocps.so.3
+# shipped in /usr. When upgrading to CL > 1786, which no longer carries
+# libprocps.so.3, copy that library from the old /usr into
+# /usr/share/oem/lib64 so open-vm-tools will continue to work.
+if [[ -e "/usr/lib64/libprocps.so.3" &&
+		! -e "/usr/share/oem/lib64/libprocps.so.3" &&
+		-e "/usr/share/oem/lib64/open-vm-tools/plugins/vmsvc/libguestInfo.so" ]] &&
+		ldd "/usr/share/oem/lib64/open-vm-tools/plugins/vmsvc/libguestInfo.so" | grep -q libprocps.so.3; then
+	cp -a "/usr/lib64/libprocps.so.3" "$(readlink -f /usr/lib64/libprocps.so.3)" \
+		/usr/share/oem/lib64/
+fi
+
 # use the cgpt binary from the image to ensure compatibility
 CGPT=
 for bindir in bin/old_bins bin sbin; do


### PR DESCRIPTION
Old versions of the VMware OEM depend on `libprocps.so.3`, which is no longer going to be shipped in `/usr`. Copy `libprocps.so.3` into `/usr/share/oem/lib64` if we detect that the OEM will need it.

Tested on:
- Current QEMU image
- 490.0.0 (first version with a `vmware` VMDK)
- 505.1.0 (first version without `libguestInfo.so` `DT_RUNPATH` set to `/usr/share/oem/lib64`)
- 540.0.0 (first version with `libguestInfo.so` `DT_RUNPATH` set again)
- 921.0.0
- 1353.1.0 (last alpha with `libguestInfo.so` linked with libprocps)
- 1367.5.0 (first version with `libguestInfo.so` not linked with libprocps)
- 1786.2.0

Tests consisted of running the upgrade, rebooting, and verifying that `vmtoolsd` was running with `libguestInfo.so` mapped and, if applicable, `libprocps.so.3` mapped from `/usr/share/oem/lib64`.

Also tested:
- 921.0.0, upgraded twice from the same package
- 1353.1.0, upgraded, booted from the old version, then re-upgraded